### PR TITLE
feature: copilot.nvimを追加

### DIFF
--- a/nvim_container/Dockerfile
+++ b/nvim_container/Dockerfile
@@ -24,9 +24,15 @@ ENV CARGO_HOME=/root/.cargo
 ENV RUSTUP_HOME=/root/.rustup
 ENV PATH="${CARGO_HOME}/bin:${PATH}"
 
+# Node.js 20.xのインストール
 RUN apt-get update && apt-get install -y \
-    curl git sudo build-essential unzip wget python3 python3-pip nodejs npm \
+    curl git sudo build-essential unzip wget python3 python3-pip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Node.js 20.xのインストール
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get update && apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain=nightly && \
     . "$HOME/.cargo/env" && rustup show
@@ -40,4 +46,3 @@ COPY --from=builder /usr/local/bin/nvim /usr/local/bin/
 COPY --from=builder /usr/local/share/nvim /usr/local/share/nvim
 
 ENTRYPOINT ["/usr/local/bin/nvim"]
-

--- a/nvim_container/config/lua/keymap.lua
+++ b/nvim_container/config/lua/keymap.lua
@@ -25,3 +25,4 @@ vim.g.maplocalleader = ";"
 require("plugins.bufferline.function")
 require("plugins.bufferline.keymap")
 require("plugins.lsp.keymap")
+require("plugins.copilot.keymap")

--- a/nvim_container/config/lua/lazy-nvim.lua
+++ b/nvim_container/config/lua/lazy-nvim.lua
@@ -15,6 +15,7 @@ vim.opt.rtp:prepend(lazypath)
 require("lazy").setup({
   require("plugins.catppuccin"),
   require("plugins.bufferline.setup"),
+  require("plugins.copilot.setup"),
   require("plugins.indent-blankline"),
   require("plugins.lsp.nvim-cmp"),
   require("plugins.lsp.nvim-lspconfig"),

--- a/nvim_container/config/lua/plugins/copilot/keymap.lua
+++ b/nvim_container/config/lua/plugins/copilot/keymap.lua
@@ -1,0 +1,4 @@
+local opts = { silent = true, expr = true }
+
+-- Copilotのキーマップ
+vim.api.nvim_set_keymap("i", "<C-J>", 'copilot#Accept("<CR>")', opts)

--- a/nvim_container/config/lua/plugins/copilot/setup.lua
+++ b/nvim_container/config/lua/plugins/copilot/setup.lua
@@ -1,0 +1,10 @@
+return {
+  "github/copilot.vim",
+  config = function()
+    -- Copilotの設定
+    vim.g.copilot_no_tab_map = true
+    vim.g.copilot_filetypes = {
+      ["*"] = true,
+    }
+  end
+}


### PR DESCRIPTION
This pull request updates the Neovim container setup by introducing Node.js 20.x installation, integrating GitHub Copilot, and making minor adjustments to the Dockerfile. The most important changes are grouped into Dockerfile improvements and Copilot integration.

### Dockerfile improvements:
* Added installation steps for Node.js 20.x using the NodeSource setup script, replacing the previous inclusion of `nodejs` and `npm` in the package list. (`nvim_container/Dockerfile`, [nvim_container/DockerfileR27-R36](diffhunk://#diff-eac7773adcf286184f5631847f79b1d37738d0a256febc523febf49d4f10b68eR27-R36))
* Removed an unnecessary blank line at the end of the Dockerfile. (`nvim_container/Dockerfile`, [nvim_container/DockerfileL43](diffhunk://#diff-eac7773adcf286184f5631847f79b1d37738d0a256febc523febf49d4f10b68eL43))

### Copilot integration:
* Added a new keymap for GitHub Copilot in `keymap.lua`. (`nvim_container/config/lua/keymap.lua`, [nvim_container/config/lua/keymap.luaR28](diffhunk://#diff-e90dbae073782e0d757deee7ca2d32ff8bd25b281ab8039cba0c34bde3a5465aR28))
* Included Copilot setup in the Lazy.nvim configuration. (`nvim_container/config/lua/lazy-nvim.lua`, [nvim_container/config/lua/lazy-nvim.luaR18](diffhunk://#diff-cd1826779a4ce1e0f492bdfba9c7d074920bbb7aa69f94f7a6b20838e8ebb351R18))
* Created a new file `copilot/keymap.lua` to define a keybinding for accepting Copilot suggestions with `<C-J>` in insert mode. (`nvim_container/config/lua/plugins/copilot/keymap.lua`, [nvim_container/config/lua/plugins/copilot/keymap.luaR1-R4](diffhunk://#diff-98867531217930b3341e1b4c984bfe1f6b5ef8e4869f8223b88c5584c87d514cR1-R4))
* Created a new file `copilot/setup.lua` to configure Copilot, including disabling the default `<Tab>` mapping and enabling Copilot for all file types. (`nvim_container/config/lua/plugins/copilot/setup.lua`, [nvim_container/config/lua/plugins/copilot/setup.luaR1-R10](diffhunk://#diff-ca9bef88360a592fa9b5dc1258d1ac92d4bf6f2379dba821c887889b66a49271R1-R10))