### PR TITLE
feature: claude codeのセットアップ

### DIFF
--- a/home_manager/.claude/settings.json
+++ b/home_manager/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(rm -rf ~)",
+      "Bash(rm -rf ~/*)",
+      "Bash(rm -rf /*)",
+      "Bash(sudo:*)",
+      "Read(flake.lock)"
+    ]
+  }
+}

--- a/home_manager/CLAUDE.md
+++ b/home_manager/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Home Manager Configuration
+- **Apply configuration**: `home-manager switch --flake .#shunsock -b backup`
+- **Install Home Manager**: `nix profile install github:nix-community/home-manager`
+
+### Nix Operations
+- **Build configuration**: `nix build .#homeConfigurations.shunsock.activationPackage`
+- **Check flake**: `nix flake check`
+- **Update flake inputs**: `nix flake update`
+
+## Architecture
+
+This is a Nix Home Manager configuration for macOS (aarch64-darwin) that manages dotfiles and system packages.
+
+### Structure
+- `flake.nix`: Main configuration defining packages, user settings, and zsh configuration
+- `zsh/`: Modular zsh configuration files organized by purpose
+  - `basic/`: Core shell configurations (aliases, editor settings, options, PATH)
+  - `command/`: Command-specific configurations (docker, git aliases)
+
+### Key Components
+- **Package Management**: Uses nixpkgs unstable channel with unfree packages allowed
+- **Shell Configuration**: Zsh with Oh My Zsh (kennethreitz theme) and modular config loading
+- **Recursive Loading**: All `.zsh` files under `~/.config/zsh/` are automatically sourced
+- **User**: Configured for user `shunsock` with home directory `/Users/shunsock`
+
+### Installed Packages
+Core development tools include: claude-code, dotnetCorePackages.dotnet_9.sdk, git, go-task, hyperfine, rustup, tree, zsh-autosuggestions, zsh-syntax-highlighting
+
+### Configuration Flow
+1. flake.nix defines the home-manager configuration
+2. Zsh files are copied to `~/.config/zsh/` recursively
+3. initContent in programs.zsh sources all `.zsh` files automatically
+4. Oh My Zsh and autosuggestions are configured last

--- a/home_manager/README.md
+++ b/home_manager/README.md
@@ -1,0 +1,94 @@
+# Home Manager
+
+A comprehensive dotfiles configuration using Nix Home Manager for macOS development environment.
+
+## Features
+
+- **Package Management**: Declarative package installation using Nix
+- **Modular Zsh Configuration**: Organized shell configuration with automatic loading
+- **Development Tools**: Pre-configured development environment with essential tools
+- **Version Control**: Git aliases and configuration
+
+## Quick Start
+
+### Prerequisites
+
+- Nix package manager installed on macOS
+- Git for cloning the repository
+
+### Installation
+
+1. **Install Home Manager**:
+   ```bash
+   nix profile install github:nix-community/home-manager
+   ```
+
+2. **Apply Configuration**:
+   ```bash
+   home-manager switch --flake .#shunsock -b backup
+   ```
+
+## Configuration Structure
+
+```
+├── flake.nix           # Main configuration file
+├── flake.lock          # Locked dependency versions
+└── zsh/                # Modular zsh configuration
+    ├── basic/          # Core shell settings
+    │   ├── alias.zsh   # System and utility aliases
+    │   ├── editor.zsh  # Editor configuration
+    │   ├── option.zsh  # Shell options
+    │   └── path.zsh    # PATH modifications
+    └── command/        # Command-specific configurations
+        ├── docker/     # Docker-related settings
+        └── git/        # Git aliases and configuration
+```
+
+## Included Packages
+
+- **Development**: claude-code, dotnetCorePackages.dotnet_9.sdk, git, go-task, rustup
+- **System Utilities**: hyperfine, tree
+- **Shell Enhancement**: zsh-autosuggestions, zsh-syntax-highlighting
+
+## Management Commands
+
+```bash
+# Apply configuration changes
+home-manager switch --flake .#shunsock -b backup
+
+# Build configuration (test without applying)
+nix build .#homeConfigurations.shunsock.activationPackage
+
+# Update all flake inputs
+nix flake update
+
+# Check flake configuration
+nix flake check
+```
+
+## Customization
+
+### Adding New Packages
+
+Edit `flake.nix` and add packages to the `home.packages` list:
+
+```nix
+home.packages = with pkgs; [
+  # existing packages...
+  your-new-package
+];
+```
+
+### Adding Zsh Configuration
+
+Create new `.zsh` files in the appropriate directory under `zsh/`. Files are automatically sourced based on the directory structure.
+
+### Modifying User Settings
+
+Update the user configuration in `flake.nix`:
+
+```nix
+home.username      = "your-username";
+home.homeDirectory = "/Users/your-username";
+```
+


### PR DESCRIPTION
This pull request introduces a new Nix Home Manager configuration for macOS, along with documentation and safety enhancements when we use cluade code. The changes include defining permissions to restrict potentially destructive commands, adding detailed documentation for configuration and usage, and providing a modular structure for Zsh configurations.

### Security Enhancements:
* Added a `settings.json` file to deny execution of potentially destructive Bash commands (e.g., `rm -rf /`) and restrict access to specific files like `flake.lock`. (`home_manager/.claude/settings.json`, [home_manager/.claude/settings.jsonR1-R12](diffhunk://#diff-fe2824997f2f6175dc95ebd3bd805b73425c7cb539913e7b4bbd342c8a748139R1-R12))

### Documentation Additions:
* Created `CLAUDE.md` to guide the usage of Claude Code with the repository, including commands for applying configurations, updating flakes, and describing the architecture and key components of the setup. (`home_manager/CLAUDE.md`, [home_manager/CLAUDE.mdR1-R39](diffhunk://#diff-97c0837ab4b6bfbf482db215437c6830a408a968fa005f28812d1565b4852a55R1-R39))
* Added `README.md` to provide an overview of the Home Manager configuration, its features, structure, and management commands, along with instructions for customization. (`home_manager/README.md`, [home_manager/README.mdR1-R94](diffhunk://#diff-75cfd41788d22ca0d84cc09a382c12fc80abf5ff113c99f7d0488461b6adea85R1-R94))