### PR TITLE
feature: add HackGen font

### DIFF
--- a/home_manager/.claude/how_to_check_font.md
+++ b/home_manager/.claude/how_to_check_font.md
@@ -1,0 +1,86 @@
+# How to Check Fonts on macOS
+
+This document describes various methods to check installed fonts on macOS, particularly useful when working with Nix Home Manager font installations.
+
+## Font Locations on macOS
+
+### User Fonts
+```bash
+ls -la ~/Library/Fonts/
+```
+- User-specific fonts installed via Home Manager or manually
+- Most commonly used location for checking if fonts are available
+
+### System Fonts
+```bash
+ls -la /System/Library/Fonts/
+```
+- System-wide fonts provided by macOS
+- Generally not modified by package managers
+
+### Nix Store Fonts
+```bash
+ls -la ~/.nix-profile/share/fonts/
+```
+- Fonts installed via Nix/Home Manager
+- Symlinks to actual font files in the nix store
+
+## Checking Specific Font Installation
+
+### Check if a specific font is installed
+```bash
+# Look for HackGen font example
+ls -la ~/Library/Fonts/ | grep -i hackgen
+```
+
+### Verify Nix font installation
+```bash
+# Check the nix store path
+ls -la ~/.nix-profile/share/fonts/
+
+# Follow symlinks to see actual font files
+ls -la /nix/store/*/share/fonts/hackgen-nf/
+```
+
+## Font Cache and System Integration
+
+### macOS Font Cache
+- macOS automatically manages font cache
+- Fonts in ~/Library/Fonts/ are immediately available to applications
+- No manual cache refresh needed unlike Linux systems
+
+### Note about fc-list
+- `fc-list` (fontconfig) is not available by default on macOS
+- Use directory listing methods instead
+- If fontconfig is needed, install via Homebrew or Nix
+
+## Common Issues and Solutions
+
+### Font not showing in applications
+1. Check if font file exists in ~/Library/Fonts/
+2. Restart the application
+3. If using Nix, ensure `fonts.fontconfig.enable = true;` is set
+
+### Nix Home Manager font installation
+- Fonts are automatically copied to ~/Library/Fonts/ when fontconfig is enabled
+- Check both the nix store and user font directory
+- Font names in applications match the font file names (without .ttf extension)
+
+## Examples
+
+### Checking HackGen Nerd Font installation
+```bash
+# Check user fonts directory
+ls -la ~/Library/Fonts/ | grep -i hackgen
+
+# Expected output:
+# HackGen35ConsoleNF-Regular.ttf
+# HackGen35ConsoleNF-Bold.ttf
+# HackGenConsoleNF-Regular.ttf
+# HackGenConsoleNF-Bold.ttf
+```
+
+### Verifying font availability for applications
+- Font name in applications: "HackGen35 Console NF"
+- Corresponds to file: "HackGen35ConsoleNF-Regular.ttf"
+- Bold variant: "HackGen35ConsoleNF-Bold.ttf"

--- a/home_manager/CLAUDE.md
+++ b/home_manager/CLAUDE.md
@@ -44,3 +44,7 @@ Core development tools include: claude-code, dotnetCorePackages.dotnet_9.sdk, gi
 2. Zsh files are copied to `~/.config/zsh/` recursively
 3. initContent in programs.zsh sources all `.zsh` files automatically
 4. Oh My Zsh and autosuggestions are configured last
+
+## Reference Documentation
+
+- **Font Management**: See `.claude/how_to_check_font.md` for checking font installations on macOS

--- a/home_manager/flake.nix
+++ b/home_manager/flake.nix
@@ -24,6 +24,9 @@
             home.homeDirectory = "/Users/shunsock";
             home.stateVersion  = "23.11";
 
+            # フォント設定
+            fonts.fontconfig.enable = true;
+
             # インストールするパッケージ
             home.packages = with pkgs; [
               claude-code
@@ -31,6 +34,7 @@
               gh
               git
               go-task
+              hackgen-nf-font
               hyperfine
               rustup
               tree


### PR DESCRIPTION
This pull request introduces documentation and configuration changes related to font management on macOS, specifically for users of Nix Home Manager. It includes a new guide for checking fonts, a reference update, and configuration adjustments to enable font management and install a specific font.

### Documentation Updates:
* [`home_manager/.claude/how_to_check_font.md`](diffhunk://#diff-a4c61c4de60e43beb99103e2649a1e37c29a15766451025e51496fe77b227cbeR1-R86): Added a comprehensive guide on checking installed fonts on macOS, covering user fonts, system fonts, Nix store fonts, font cache behavior, and troubleshooting common font issues.
* [`home_manager/CLAUDE.md`](diffhunk://#diff-97c0837ab4b6bfbf482db215437c6830a408a968fa005f28812d1565b4852a55R47-R50): Added a reference to the new font management guide in the documentation.

### Configuration Changes:
* [`home_manager/flake.nix`](diffhunk://#diff-e6f6a0452a7a2b6252f41d9f4504b8793d6c0b0971f22df6e75b5d82a8677c5bR27-R37): Enabled `fonts.fontconfig` and added the `hackgen-nf-font` package to the list of installed fonts, ensuring proper font management and availability.