### PR TITLE
refactor: zsh

### DIFF
--- a/home_manager/flake.nix
+++ b/home_manager/flake.nix
@@ -22,7 +22,7 @@
         modules = [
           # System configuration
           {
-            system.stateVersion = 1;
+            system.stateVersion = 4;
             system.primaryUser = "shunsock";
             nixpkgs.config.allowUnfree = true;
           }

--- a/home_manager/flake.nix
+++ b/home_manager/flake.nix
@@ -22,7 +22,7 @@
         modules = [
           # System configuration
           {
-            system.stateVersion = "23.05";
+            system.stateVersion = 1;
             system.primaryUser = "shunsock";
             nixpkgs.config.allowUnfree = true;
           }

--- a/home_manager/flake.nix
+++ b/home_manager/flake.nix
@@ -25,6 +25,7 @@
             system.stateVersion = 4;
             system.primaryUser = "shunsock";
             nixpkgs.config.allowUnfree = true;
+            ids.gids.nixbld = 350;
           }
           
           # Homebrew configuration

--- a/home_manager/home.nix
+++ b/home_manager/home.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./modules/wezterm.nix
+    ./modules/zsh.nix
   ];
 
   # ユーザー情報
@@ -24,34 +25,6 @@
     hyperfine
     rustup
     tree
-    zsh-autosuggestions
-    zsh-syntax-highlighting
   ];
 
-  # zsh 設定ファイルを再帰的に配置
-  home.file.".config/zsh".source    = ./zsh;
-  home.file.".config/zsh".recursive = true;
-
-  # Zsh と Oh My Zsh の設定
-  programs.zsh = {
-    enable = true;
-
-    # Oh My Zsh を有効化しテーマを設定
-    "oh-my-zsh" = {
-      enable  = true;
-      theme   = "kennethreitz";
-      plugins = [];
-    };
-
-    # ~/.config/zsh 以下を再帰的に source
-    initContent = ''
-      setopt extendedglob
-      for f in $HOME/.config/zsh/**/*.zsh; do
-        source "$f"
-      done
-
-      # zsh-autosuggestions を最後に読み込み
-      source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh
-    '';
-  };
 }

--- a/home_manager/modules/zsh.nix
+++ b/home_manager/modules/zsh.nix
@@ -1,0 +1,36 @@
+{ config, pkgs, ... }:
+
+{
+  # zsh 設定ファイルを再帰的に配置
+  home.file.".config/zsh".source    = ../zsh;
+  home.file.".config/zsh".recursive = true;
+
+  # Zsh関連パッケージ
+  home.packages = with pkgs; [
+    zsh-autosuggestions
+    zsh-syntax-highlighting
+  ];
+
+  # Zsh と Oh My Zsh の設定
+  programs.zsh = {
+    enable = true;
+
+    # Oh My Zsh を有効化しテーマを設定
+    "oh-my-zsh" = {
+      enable  = true;
+      theme   = "kennethreitz";
+      plugins = [];
+    };
+
+    # ~/.config/zsh 以下を再帰的に source
+    initContent = ''
+      setopt extendedglob
+      for f in $HOME/.config/zsh/**/*.zsh; do
+        source "$f"
+      done
+
+      # zsh-autosuggestions を最後に読み込み
+      source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+    '';
+  };
+}


### PR DESCRIPTION
This pull request refactors and modularizes the configuration for Zsh in the Home Manager setup, introduces a new module for Zsh, and updates system-related configurations. The main changes include moving Zsh-specific configurations to a dedicated module, updating the `system.stateVersion` format, and adding a new group ID for `nixbld`.

### System Configuration Updates:
* Changed `system.stateVersion` from a string ("23.05") to an integer (`4`) for consistency or compatibility.
* Added a new group ID (`350`) for `nixbld` to the configuration.

### Zsh Configuration Modularization:
* Removed Zsh-specific configurations (e.g., `programs.zsh` setup, Zsh-related packages, and `.config/zsh` file handling) from `home_manager/home.nix`.
* Introduced a new module, `modules/zsh.nix`, to encapsulate all Zsh-related configurations, including package installations, `.config/zsh` file handling, and Oh My Zsh setup.

### Home Manager Configuration Updates:
* Added `./modules/zsh.nix` to the `imports` list in `home_manager/home.nix` to integrate the new Zsh module.