### PR TITLE
feature: zoom

### DIFF
--- a/asagi/flake.lock
+++ b/asagi/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751729568,
-        "narHash": "sha256-ay7O1jjalUxkL23QWLv9C2s8rdVGs3hUOPZClIbUHKs=",
+        "lastModified": 1751760902,
+        "narHash": "sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f117b383dd591fd579bce5ee7bac07a3fdc1d050",
+        "rev": "8b0180dde1d6f4cf632e046309e8f963924dfbd0",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751271578,
-        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
+        "lastModified": 1751637120,
+        "narHash": "sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8++xWA8itO4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
+        "rev": "5c724ed1388e53cc231ed98330a60eb2f7be4be3",
         "type": "github"
       },
       "original": {

--- a/asagi/flake.nix
+++ b/asagi/flake.nix
@@ -1,6 +1,6 @@
 {
   description = "Flake for macOS";
-inputs = {
+  inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nix-darwin.url = "github:LnL7/nix-darwin";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
@@ -46,7 +46,7 @@ inputs = {
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
             home-manager.users.shunsock = import ./home.nix;
-            home-manager.backupFileExtension = ".hm-backup";
+            home-manager.backupFileExtension = "hm-backup";
           }
         ];
       };

--- a/asagi/flake.nix
+++ b/asagi/flake.nix
@@ -47,6 +47,8 @@
             home-manager.useUserPackages = true;
             home-manager.users.shunsock = import ./home.nix;
             home-manager.backupFileExtension = "hm-backup";
+            # Explicitly set home directory to avoid null value
+            home-manager.users.shunsock.home.homeDirectory = "/Users/shunsock";
           }
         ];
       };

--- a/asagi/flake.nix
+++ b/asagi/flake.nix
@@ -47,8 +47,6 @@
             home-manager.useUserPackages = true;
             home-manager.users.shunsock = import ./home.nix;
             home-manager.backupFileExtension = "hm-backup";
-            # Explicitly set home directory to avoid null value
-            home-manager.users.shunsock.home.homeDirectory = "/Users/shunsock";
           }
         ];
       };

--- a/asagi/flake.nix
+++ b/asagi/flake.nix
@@ -32,9 +32,10 @@ inputs = {
             homebrew = {
               enable = true;
               casks = [
-                "wezterm"
                 "aquaskk"
                 "docker"
+                "wezterm"
+                "zoom"
               ];
             };
           }

--- a/asagi/home.nix
+++ b/asagi/home.nix
@@ -9,7 +9,7 @@
 
   # ユーザー情報
   home.username      = "shunsock";
-  home.homeDirectory = "/Users/shunsock";
+  home.homeDirectory = lib.mkForce "/Users/shunsock";
   home.stateVersion  = "23.11";
 
   # フォント設定

--- a/asagi/home.nix
+++ b/asagi/home.nix
@@ -1,12 +1,6 @@
 { config, pkgs, lib, ... }:
 
-let
-  homeDir = config.home.homeDirectory;
-in {
-  home.activation.cleanOldAquaSKK = lib.hm.dag.entryBefore ["writeBoundary"] ''
-  rm -f "${config.home.homeDirectory}/Library/Application Support/AquaSKK/"*".hm-backup"
-'';
-
+{
   imports = [
     ./modules/wezterm.nix
     ./modules/zsh.nix
@@ -15,7 +9,6 @@ in {
 
   # ユーザー情報
   home.username      = "shunsock";
-  home.homeDirectory = pkgs.lib.mkForce "/Users/shunsock";
   home.stateVersion  = "23.11";
 
   # フォント設定

--- a/asagi/home.nix
+++ b/asagi/home.nix
@@ -9,6 +9,7 @@
 
   # ユーザー情報
   home.username      = "shunsock";
+  home.homeDirectory = "/Users/shunsock";
   home.stateVersion  = "23.11";
 
   # フォント設定

--- a/asagi/home.nix
+++ b/asagi/home.nix
@@ -1,6 +1,12 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
-{
+let
+  homeDir = config.home.homeDirectory;
+in {
+  home.activation.cleanOldAquaSKK = lib.hm.dag.entryBefore ["writeBoundary"] ''
+  rm -f "${config.home.homeDirectory}/Library/Application Support/AquaSKK/"*".hm-backup"
+'';
+
   imports = [
     ./modules/wezterm.nix
     ./modules/zsh.nix
@@ -27,5 +33,4 @@
     rustup
     tree
   ];
-
 }

--- a/asagi/modules/skk.nix
+++ b/asagi/modules/skk.nix
@@ -1,13 +1,9 @@
 { config, pkgs, ... }:
 
 {
-  # SKK configuration files
-  home.file = {
-    "Library/Application Support/AquaSKK/BlacklistApps.plist".source = ../configs/skk/BlacklistApps.plist;
-    "Library/Application Support/AquaSKK/DictionarySet.plist".source = ../configs/skk/DictionarySet.plist;
-    "Library/Application Support/AquaSKK/SKK-JISYO.L".source = ../configs/skk/SKK-JISYO.L;
-    "Library/Application Support/AquaSKK/keymap.conf".source = ../configs/skk/keymap.conf;
-    "Library/Application Support/AquaSKK/skk-jisho.user.utf8".source = ../configs/skk/skk-jisho.user.utf8;
-    "Library/Application Support/AquaSKK/skk-jisyo.utf8".source = ../configs/skk/skk-jisyo.utf8;
+  home.file."Library/Application Support/AquaSKK" = {
+    source    = ../configs/skk;
+    recursive = true;
+    backup    = false;
   };
 }

--- a/asagi/modules/skk.nix
+++ b/asagi/modules/skk.nix
@@ -4,6 +4,5 @@
   home.file."Library/Application Support/AquaSKK" = {
     source    = ../configs/skk;
     recursive = true;
-    backup    = false;
   };
 }


### PR DESCRIPTION
This pull request introduces several updates to the `asagi` configuration files, focusing on improving package management, simplifying configuration, and refactoring file handling. Key changes include adjustments to Homebrew and Home Manager configurations, updates to file imports, and a significant refactor of SKK configuration file handling.

### Package management updates:
* [`asagi/flake.nix`](diffhunk://#diff-e2adb2b8c097f049227c43e0c46033521ee4d665de2bce05589e40afca64dd37L35-R38): Added `zoom` to the Homebrew casks list and reordered `wezterm` for consistency.

### Configuration improvements:
* [`asagi/flake.nix`](diffhunk://#diff-e2adb2b8c097f049227c43e0c46033521ee4d665de2bce05589e40afca64dd37L48-R49): Updated `home-manager.backupFileExtension` to remove the leading period for better compatibility.
* [`asagi/home.nix`](diffhunk://#diff-00ede06396027124ca2d63fce6671714fb391a42cf8dba544d91d2e546a82b27L12-R12): Replaced `pkgs.lib` with `lib` for `home.homeDirectory` to align with existing imports and simplify the code.

### Refactoring:
* [`asagi/home.nix`](diffhunk://#diff-00ede06396027124ca2d63fce6671714fb391a42cf8dba544d91d2e546a82b27L1-R1): Added `lib` to the argument list, reflecting its usage in the file.
* [`asagi/modules/skk.nix`](diffhunk://#diff-166078974bd97f29353aab9e3f46d580bfaf8521613a05c966577044e0926b55L4-R6): Refactored SKK configuration handling to use a single recursive directory source instead of defining individual file sources, reducing redundancy.