### PR TITLE
feature: arc

### DIFF
--- a/asagi/Taskfile.yml
+++ b/asagi/Taskfile.yml
@@ -13,6 +13,7 @@ tasks:
   apply:
     desc: Apply the configuration with darwin-rebuild
     cmds:
+      - bash script/remove_backup.sh
       - sudo darwin-rebuild switch --flake .#shunsock-darwin
 
   build:

--- a/asagi/flake.nix
+++ b/asagi/flake.nix
@@ -1,6 +1,5 @@
 {
-  description = "Flake for macOS";
-  inputs = {
+  description = "Flake for macOS"; inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nix-darwin.url = "github:LnL7/nix-darwin";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
@@ -48,13 +47,6 @@
             home-manager.useUserPackages = true;
             home-manager.users.shunsock = import ./home.nix;
             home-manager.backupFileExtension = "hm-backup";
-            # 既存バックアップを自動削除するアクティベーション
-            home.activation.cleanupOldSKKBackup = {
-              after = [ "writeBoundary" ];
-              script = ''
-                rm -f "${config.home.homeDirectory}/Library/Application Support/AquaSKK/skk-jisyo.utf8.${config.home-manager.backupFileExtension}"
-              '';
-            };
           }
         ];
       };

--- a/asagi/script/remove_backup.sh
+++ b/asagi/script/remove_backup.sh
@@ -1,0 +1,9 @@
+TARGET="/Users/shunsock/Library/Application Support/AquaSKK/skk-jisyo.utf8.hm-backup"
+
+if [ -e "$TARGET" ]; then
+  rm "$TARGET"
+  echo "削除しました: $TARGET"
+else
+  echo "ファイルが存在しません: $TARGET"
+fi
+


### PR DESCRIPTION
This pull request introduces a script to manage backup files, updates the configuration for macOS packages, and simplifies the `flake.nix` file. The key changes include adding a script to remove a specific backup file, modifying the `Taskfile.yml` to incorporate this script, adding a new application to the list of macOS casks, and refactoring the `flake.nix` file for improved readability.

### Script Management:
* Added a new script `remove_backup.sh` to delete a specific backup file (`skk-jisyo.utf8.hm-backup`) if it exists. The script provides feedback on whether the file was deleted or not found. (`asagi/script/remove_backup.sh`)

### Taskfile Updates:
* Updated `Taskfile.yml` to include the `remove_backup.sh` script as part of the `apply` task, ensuring the backup file is removed before applying the configuration. (`asagi/Taskfile.yml`)

### macOS Package Configuration:
* Added the `arc` application to the list of macOS casks in the `flake.nix` configuration. (`asagi/flake.nix`)

### Code Simplification:
* Refactored the `flake.nix` file by combining the `description` and `inputs` declarations into a single line for improved readability. (`asagi/flake.nix`)