### PR TITLE
feature: akatsukiをasagiに導入

### DIFF
--- a/asagi/configs/zsh/basic/alias.zsh
+++ b/asagi/configs/zsh/basic/alias.zsh
@@ -54,13 +54,21 @@ alias la='ls -Fha'
 # -------------------------------------------------------------------
 
 alias vi='vim'
+alias nvim='vim'
 alias v='docker run -it --rm \
   -v "$PWD":/workspace \
-  -v "$HOME/.nvimc/share":/root/.local/share/nvim \
-  -v "$HOME/.nvimc/cache":/root/.cache/nvim \
-  -v "$HOME/.nvimc/state":/root/.local/state/nvim \
+  -v "$HOME/.akatsuki-default/share":/root/.local/share/nvim \
+  -v "$HOME/.akatsuki-default/cache":/root/.cache/nvim \
+  -v "$HOME/.akatsuki-default/state":/root/.local/state/nvim \
   -w /workspace \
-  tsuchiya55docker/nvimc:v0.0.6'
+  tsuchiya55docker/akatsuki:default-0.0.1'
+alias vpy='docker run -it --rm \
+  -v "$PWD":/workspace \
+  -v "$HOME/.akatsuki-python/share":/root/.local/share/nvim \
+  -v "$HOME/.akatsuki-python/cache":/root/.cache/nvim \
+  -v "$HOME/.akatsuki-python/state":/root/.local/state/nvim \
+  -w /workspace \
+  tsuchiya55docker/akatsuki:python-0.0.1'
 
 # -------------------------------------------------------------------
 # df Command


### PR DESCRIPTION
This pull request updates and expands the set of shell aliases related to Neovim usage in the `alias.zsh` configuration file. The main focus is on improving Docker-based Neovim workflows and adding a new alias for Python-specific Neovim environments.

**Neovim Docker alias improvements:**

* Changed the `v` alias to use the new Docker image `tsuchiya55docker/akatsuki:default-0.0.1` and updated its volume mounts to use the `.akatsuki-default` directory instead of `.nvimc`.
* Added a new `vpy` alias for running Neovim in a Python-focused Docker container (`tsuchiya55docker/akatsuki:python-0.0.1`) with corresponding `.akatsuki-python` volume mounts.

**General Neovim alias:**

* Added an alias `nvim` to run `vim`, providing a fallback for users who type `nvim`.