### PR TITLE
Feature/nixos skk

### DIFF
--- a/azuma/configuration.nix
+++ b/azuma/configuration.nix
@@ -118,7 +118,6 @@
     curl
     fastfetch
     gh
-    ddskk
     vim
   ];
 


### PR DESCRIPTION
This pull request refactors and improves the `azuma/configuration.nix` NixOS configuration file, focusing on better organization, updated service configuration, and enhanced input method and font support. The most important changes are grouped below.

**Configuration Structure and Service Updates**

* Reformatted several configuration blocks for clarity, such as splitting previously combined service declarations into separate lines and blocks. This includes updates to the GNOME desktop environment and sound services. (`azuma/configuration.nix`) [[1]](diffhunk://#diff-b381c94f3e681132b27686c83fad1f6df3bcb3a5018bc41955ec08a344c98d37L67-R85) [[2]](diffhunk://#diff-b381c94f3e681132b27686c83fad1f6df3bcb3a5018bc41955ec08a344c98d37L77-L87)
* Updated `networking` and `i18n` sections, removing commented-out proxy settings and improving locale settings formatting. (`azuma/configuration.nix`) [[1]](diffhunk://#diff-b381c94f3e681132b27686c83fad1f6df3bcb3a5018bc41955ec08a344c98d37L21-R21) [[2]](diffhunk://#diff-b381c94f3e681132b27686c83fad1f6df3bcb3a5018bc41955ec08a344c98d37L36-R63)

**Input Method and Font Enhancements**

* Overhauled the input method configuration to use a more explicit and feature-rich `fcitx5` setup, enabling Wayland frontend and adding more addons for broader language support. (`azuma/configuration.nix`)
* Changed font configuration from `fonts.fonts` to `fonts.packages`, ensuring correct font package installation and improved compatibility. (`azuma/configuration.nix`)

**Additional Program Support**

* Enabled the `dconf` program alongside `git`, improving GNOME desktop settings management. (`azuma/configuration.nix`)