### PR TITLE
fix: wezterm

### DIFF
--- a/asagi/modules/wezterm.nix
+++ b/asagi/modules/wezterm.nix
@@ -33,7 +33,6 @@
       -- Tab bar settings
       config.window_decorations = "RESIZE"
       config.show_new_tab_button_in_tab_bar = false
-      config.show_close_tab_button_in_tabs = false
       config.colors = {
          tab_bar = {
            inactive_tab_edge = "none",


### PR DESCRIPTION
This pull request makes a small change to the tab bar configuration in the `asagi/modules/wezterm.nix` file. The change removes the setting that hides the close tab button in tabs, so the close tab button will now be visible.