### PR TITLE
document: update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,32 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a comprehensive dotfiles repository containing three main projects:
 
-- **`asagi/`** - Nix Darwin configuration (active, primary system)
-- **`homem/`** - Legacy Go-based dotfiles manager (deprecated)
-- **`yamabuki/`** - Dockerized Neovim container
+- **`asagi/`** - Nix Darwin configuration for macOS (active)
+- **`azuma/`** - NixOS configuration for Linux (active)
+- **`akatsuki/`** - Docker container environments (active)
 
 ## Commands
 
-### Root Level (Legacy homem system)
-```bash
-# Go development
-task fmt          # Format Go code
-task test         # Run tests with coverage
-task build        # Build all binaries to bin/darwin/
-
-# Update configurations (deprecated - use asagi instead)
-task update-wezterm
-task update-nvim
-task update-nix
-task update-vscode
-task update-zsh
-
-# Install dependencies
-task install-font     # Download and install fonts
-task install-jetpack  # Install Neovim jetpack plugin manager
-```
-
-### Asagi (Primary Nix Darwin System)
+### Asagi (Nix Darwin for macOS)
 ```bash
 cd asagi/
 
@@ -50,51 +31,91 @@ nix flake check
 nix flake update
 ```
 
-### Yamabuki (Neovim Container)
+### Azuma (NixOS for Linux)
 ```bash
-cd yamabuki/
+cd azuma/
 
-# Container operations
-docker build -t nvimc .
-docker run -it --rm -v "$PWD":/workspace -v "$HOME/.nvimc/share":/root/.local/share/nvim -v "$HOME/.nvimc/cache":/root/.cache/nvim -v "$HOME/.nvimc/state":/root/.local/state/nvim -w /workspace nvimc
+# System management
+sudo nixos-rebuild switch --flake .#myNixOS  # Apply configuration
+nix flake check                               # Validate flake
+nix flake update                              # Update dependencies
 
-# Or use pre-built image
-docker pull tsuchiya55docker/nvimc:v0.0.2
+# Direct commands (if needed)
+nix build .#nixosConfigurations.myNixOS.config.system.build.toplevel
+```
+
+### Akatsuki (Docker Containers)
+```bash
+cd akatsuki/
+
+# Build containers
+task build:default:arm    # Build ARM architecture container
+task build:default:amd    # Build AMD/Intel architecture container
+task build:python         # Build Python development container
+
+# Run containers
+task run:default:arm /path/to/workspace
+task run:default:amd /path/to/workspace
+task run:python /path/to/workspace
+
+# Push to registry (requires authentication)
+task push                 # Push all containers
+task push:python         # Push Python container only
 ```
 
 ## Architecture
 
-### Active System: Asagi (Nix Darwin)
+### Asagi (Nix Darwin for macOS)
 - **Purpose**: Declarative macOS system configuration using Nix Darwin
 - **Target**: aarch64-darwin (Apple Silicon Macs)
 - **User**: shunsock with home directory `/Users/shunsock`
 - **Configuration Flow**:
   1. `flake.nix` - Main system configuration with Homebrew integration
   2. `home.nix` - Home Manager configuration importing modular components
-  3. `modules/` - Modular configurations (wezterm.nix, zsh.nix, skk.nix)
+  3. `modules/` - Modular configurations (claude.nix, firefox.nix, skk.nix, wezterm.nix, zsh.nix)
   4. `configs/` - Raw configuration files organized by tool
 
 **Key Features**:
-- Homebrew casks: wezterm, aquaskk
-- Home Manager packages: claude-code, dotnet 9 SDK, gh, git, go-task, hackgen-nf-font, hyperfine, rustup, tree
+- Homebrew casks: wezterm, aquaskk, arc, docker, steam, zoom
+- Home Manager packages: claude-code, dotnet 10 SDK, gh, git, go-task, hackgen-nf-font, hyperfine, mise, rustup, tree
 - Modular zsh configuration with automatic loading
 - SKK Japanese input configuration
 - Font management with fontconfig
 
-### Legacy System: Homem (Go-based Manager)
-- **Purpose**: Type-safe dotfiles synchronization system
-- **Language**: Go 1.22.7
-- **Architecture**: 
-  - 5 entry points: nix, nvim, vscode, wezterm, zsh
-  - Type-safe path handling with FilePath, DirectoryPath, NonExistentDirectoryPath
-  - Safe file operations through internal/handler and internal/updater packages
-- **Test Coverage**: 70.6% handlers, 87.1% path utilities
+### Azuma (NixOS for Linux)
+- **Purpose**: Complete Linux desktop environment using NixOS
+- **Target**: x86_64-linux
+- **User**: shunsock
+- **Configuration Flow**:
+  1. `flake.nix` - NixOS system configuration
+  2. `configuration.nix` - Main system configuration
+  3. `hardware-configuration.nix` - Hardware-specific settings
+  4. `modules/` - Modular configurations (claude-code.nix, neovim.nix, wezterm.nix, zsh.nix)
+  5. `configs/` - Raw configuration files organized by tool
 
-### Container System: Yamabuki (Neovim)
-- **Purpose**: Containerized Neovim environment
-- **Base**: Alpine Linux with Neovim and plugin ecosystem
-- **Volume Mounts**: Workspace, share, cache, state directories
-- **Configuration**: Lua-based modular plugin system with lazy loading
+**Key Features**:
+- GNOME Desktop Environment with GDM
+- Fcitx5 Japanese input with SKK support
+- Docker support with user in docker group
+- System packages: curl, fastfetch, gh, go-task, vim
+- Fonts: Noto CJK, Noto Emoji, JetBrains Mono Nerd Font
+- Starship prompt, Git, Dconf
+
+### Akatsuki (Docker Containers)
+- **Purpose**: Portable development environments in Docker containers
+- **Base**: Ubuntu 24.04
+- **Architecture**: Multi-architecture support (ARM and AMD64)
+- **Available Images**:
+  1. `akatsuki-default-arm` - ARM architecture development environment
+  2. `akatsuki-default-amd` - AMD/Intel architecture development environment
+  3. `akatsuki-python` - Python-focused development environment
+
+**Key Features**:
+- Neovim v0.11.1 from source
+- Node.js 24.x
+- .NET 8.0 SDK
+- Docker registry: tsuchiya55docker/akatsuki
+- Volume mounting for workspace and persistent data
 
 ## Important Notes
 
@@ -103,18 +124,18 @@ docker pull tsuchiya55docker/nvimc:v0.0.2
 - **Docker Operations**: Docker commands may require manual execution depending on setup
 
 ### Development Workflow
-1. **Primary System**: Use asagi for system-wide configuration changes
-2. **Testing**: Use `task build` and `task validate` before applying changes
-3. **Go Development**: Use homem for understanding the legacy configuration manager
-4. **Neovim Development**: Use yamabuki for containerized Neovim development
+1. **macOS Development**: Use asagi for macOS system configuration changes
+2. **Linux Development**: Use azuma for Linux system configuration changes
+3. **Container Development**: Use akatsuki for portable development environments
+4. **Testing**: Use `task build` and `task validate` (asagi) or `nix flake check` (azuma) before applying changes
 
 ### File Organization
 - Configuration files are organized by tool within each project
 - Nix configurations use modular imports for maintainability
-- Go project follows clean architecture with internal packages
-- Lua configurations use plugin-specific directories with setup/keymap separation
+- Both asagi and azuma share similar modular structure for consistency
+- Docker containers use multi-stage builds for optimization
 
-## Migration Status
-- **Active**: asagi (Nix Darwin) - current production system
-- **Deprecated**: homem (Go manager) - legacy system, not actively maintained
-- **Specialized**: yamabuki (Neovim container) - development environment
+## Project Status
+- **Active**: asagi (Nix Darwin) - macOS system configuration
+- **Active**: azuma (NixOS) - Linux system configuration
+- **Active**: akatsuki (Docker) - Portable container environments

--- a/README.md
+++ b/README.md
@@ -30,17 +30,16 @@ A comprehensive development environment configuration using Nix Darwin, Go-based
 
 ```
 dotfiles/
-├── asagi/          # Primary Nix Darwin configuration
-├── homem/          # Legacy Go-based configuration manager
-├── yamabuki/       # Containerized Neovim environment
-└── Taskfile.yml    # Legacy task automation
+├── asagi/          # Nix Darwin configuration for macOS
+├── azuma/          # NixOS configuration for Linux
+└── akatsuki/       # Docker container environments
 ```
 
 ## Projects
 
-### 🚀 Asagi (Primary System)
+### 🚀 Asagi
 
-**Modern Nix Darwin configuration for macOS**
+**Nix Darwin configuration for macOS**
 
 - **Target**: Apple Silicon Macs (aarch64-darwin)
 - **Features**: Declarative system configuration, package management, modular shell setup
@@ -51,7 +50,7 @@ dotfiles/
 - Home Manager integration
 - Modular Zsh configuration with automatic loading
 - SKK Japanese input support
-- Development tools: Claude Code, .NET 9 SDK, Rust, Go Task
+- Development tools: Claude Code, .NET 10 SDK, Rust, Go Task, mise
 
 **Quick Commands**:
 ```bash
@@ -61,39 +60,47 @@ task build     # Test build without applying
 task validate  # Comprehensive validation
 ```
 
-### 🏗️ Homem (Legacy)
+### 🐧 Azuma
 
-**Go-based dotfiles synchronization system**
+**NixOS configuration for Linux systems**
 
-- **Language**: Go 1.22.7
-- **Features**: Type-safe file operations, multi-tool configuration management
-- **Status**: ⚠️ Deprecated
+- **Target**: x86_64-linux
+- **Features**: Complete Linux desktop environment with GNOME, development tools
+- **Status**: ✅ Active
 
-**Architecture**:
-- 5 executable entry points (nix, nvim, vscode, wezterm, zsh)
-- Type-safe path handling with custom types
-- Comprehensive test coverage (70.6% handlers, 87.1% path utilities)
+**Key Components**:
+- NixOS system configuration with flakes
+- GNOME Desktop Environment
+- Fcitx5 Japanese input (SKK)
+- Docker support
+- Development tools: WezTerm, Neovim, Claude Code, Git
 
-**Development Commands**:
+**Quick Commands**:
 ```bash
-task fmt      # Format Go code
-task test     # Run tests with coverage
-task build    # Build all binaries
+cd azuma/
+sudo nixos-rebuild switch --flake .#myNixOS
+nix flake update
 ```
 
-### 🐳 Yamabuki (Neovim Container)
+### 🐳 Akatsuki
 
-**Containerized Neovim development environment**
+**Docker container environments for development**
 
-- **Base**: Alpine Linux with Neovim
-- **Features**: Lua-based plugin system, portable development environment
-- **Status**: ✅ Active for development
+- **Base**: Ubuntu 24.04
+- **Features**: Pre-configured development containers with Neovim
+- **Status**: ✅ Active
 
-**Usage**:
+**Available Containers**:
+- `akatsuki-default-arm` - ARM architecture
+- `akatsuki-default-amd` - AMD/Intel architecture
+- `akatsuki-python` - Python development environment
+
+**Quick Commands**:
 ```bash
-cd yamabuki/
-docker build -t nvimc .
-docker run -it --rm -v "$PWD":/workspace nvimc
+cd akatsuki/
+task build:default:arm    # Build ARM container
+task run:default:arm      # Run ARM container
+task build:python         # Build Python container
 ```
 
 ## Development Environment
@@ -102,16 +109,21 @@ docker run -it --rm -v "$PWD":/workspace nvimc
 
 **System Packages** (via Asagi):
 - Claude Code - AI-powered development assistant
-- .NET 9 SDK - Cross-platform development
+- .NET 10 SDK - Cross-platform development
 - Git & GitHub CLI - Version control
 - Go Task - Task automation
 - Rust toolchain - Systems programming
 - Hyperfine - Command-line benchmarking
 - Tree - Directory visualization
+- mise - Polyglot runtime manager
 
 **Homebrew Casks**:
 - WezTerm - GPU-accelerated terminal
 - AquaSKK - Japanese input method
+- Arc - Modern web browser
+- Docker - Container platform
+- Steam - Gaming platform
+- Zoom - Video conferencing
 
 ### Shell Configuration
 
@@ -138,22 +150,24 @@ configs/zsh/
 
 ### Daily Development
 
-1. **System Updates**:
+1. **macOS System Updates** (Asagi):
    ```bash
    cd asagi/
    task update    # Update dependencies
    task apply     # Apply changes
    ```
 
-2. **Configuration Changes**:
-   - Edit files in `asagi/configs/`
-   - Test with `task build`
-   - Apply with `task apply`
-
-3. **Container Development**:
+2. **Linux System Updates** (Azuma):
    ```bash
-   cd yamabuki/
-   docker run -it --rm -v "$PWD":/workspace nvimc
+   cd azuma/
+   sudo nixos-rebuild switch --flake .#myNixOS
+   ```
+
+3. **Container Development** (Akatsuki):
+   ```bash
+   cd akatsuki/
+   task build:default:arm
+   task run:default:arm /path/to/workspace
    ```
 
 ### Adding New Packages
@@ -174,36 +188,40 @@ Create new `.zsh` files in `asagi/configs/zsh/`:
 
 ## Architecture Notes
 
+### Configuration Management
+
+**Declarative Systems**:
+- **Asagi** (macOS): Nix Darwin + Home Manager
+- **Azuma** (Linux): NixOS with flakes
+
+Both use modular imports to organize configurations by tool, making them maintainable and reusable.
+
+### Multi-Platform Support
+
+This repository supports multiple platforms:
+- **macOS**: Native system via Nix Darwin (aarch64-darwin)
+- **Linux**: Native system via NixOS (x86_64-linux)
+- **Containers**: Portable environments via Docker (multi-arch)
+
 ### Configuration Flow
 
-1. **Nix Darwin** manages system-level configuration
-2. **Home Manager** handles user-space configuration  
-3. **Modular imports** organize configuration by tool
-4. **Automatic loading** reduces manual configuration management
+1. **Nix-based systems** manage both system and user-space configuration
+2. **Modular imports** organize configuration by tool
+3. **Automatic loading** reduces manual configuration management
+4. **Flakes** ensure reproducible builds
 
-### Type Safety
+## Project Status
 
-The legacy Go system demonstrates type-safe configuration management:
-- `FilePath` - Guarantees file existence
-- `DirectoryPath` - Guarantees directory existence
-- `NonExistentDirectoryPath` - Safe for creation operations
-
-### Environment Variables
-
-All systems support environment variable expansion (e.g., `$HOME`, `$ZSH`) for portability across different user environments.
-
-## Migration Status
-
-- **✅ Current**: Asagi (Nix Darwin) - Primary development system
-- **⚠️ Deprecated**: Homem (Go) - Legacy system, reference only
-- **✅ Specialized**: Yamabuki (Container) - Development environment
+- **✅ Active**: Asagi - macOS system configuration
+- **✅ Active**: Azuma - Linux system configuration
+- **✅ Active**: Akatsuki - Docker container environments
 
 ## Troubleshooting
 
 ### Common Issues
 
-1. **Sudo permissions**: Some commands require manual execution
-2. **Nix Darwin not found**: Run `task init` first
+1. **Sudo permissions**: Some commands (Nix Darwin/NixOS rebuilds) require manual execution
+2. **Nix not found**: Install Nix package manager first
 3. **Container issues**: Ensure Docker is running
 
 ### Getting Help


### PR DESCRIPTION
This pull request updates the documentation to reflect a major reorganization and modernization of the dotfiles repository. The changes deprecate legacy systems (such as the Go-based manager and the Neovim-only container) and introduce a new structure with three active projects: `asagi` (macOS with Nix Darwin), `azuma` (Linux with NixOS), and `akatsuki` (multi-architecture Docker containers). The documentation is rewritten to clarify usage, commands, architecture, and project status for each environment.

**Project and Architecture Updates:**

* Replaced references to legacy projects (`homem`, `yamabuki`) with new, actively maintained projects: `azuma` for NixOS/Linux and `akatsuki` for Docker containers, alongside `asagi` for macOS. Updated project descriptions, directory structure, and quick-start commands in both `README.md` and `CLAUDE.md`. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L9-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R42)
* Documented the architecture, configuration flow, and key features for each project, including supported platforms, modular configuration, and the use of Nix flakes for reproducibility. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L53-R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L177-R224)

**Command and Usage Documentation:**

* Updated and reorganized command examples for each environment, including system rebuilds, flake updates, and container build/run commands, and clarified which commands apply to macOS (`asagi`), Linux (`azuma`), and Docker (`akatsuki`). [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L53-R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L141-R170)

**Tooling and Package Updates:**

* Refreshed lists of included tools and packages, such as upgrading from .NET 9 to .NET 10 SDK, adding `mise` as a runtime manager, and expanding Homebrew casks to include Arc, Docker, Steam, and Zoom. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L53-R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R53) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L105-R126)

**Project Status and Migration:**

* Updated project status sections to clearly indicate which systems are active and which are deprecated, removing references to the legacy Go-based manager and Neovim container. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L106-R141) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L177-R224)

These changes bring the documentation up to date with the current state of the repository and provide clear guidance for users on how to work with each supported environment.