### PR TITLE
activate custom zsh

### DIFF
--- a/azuma/modules/zsh.nix
+++ b/azuma/modules/zsh.nix
@@ -27,12 +27,10 @@
     # Source custom configuration files
     interactiveShellInit = ''
       unalias -m '*'
-
-      # Source all custom zsh files from /etc/zsh/custom
-      # setopt extendedglob
-      # for f in /etc/zsh/custom/**/*.zsh; do
-      #  source "$f"
-      # done
+      setopt extendedglob
+      for f in /etc/zsh/custom/**/*.zsh; do
+       source "$f"
+      done
 
       # Load zsh-autosuggestions (must be loaded after other configs)
       source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh


### PR DESCRIPTION
This pull request updates the initialization logic for custom Zsh configuration files. The commented-out block for sourcing custom Zsh files from `/etc/zsh/custom` has been enabled, allowing all `.zsh` files in that directory (and its subdirectories) to be sourced automatically when starting an interactive shell.

Improvements to shell initialization:

* Enabled sourcing of all custom Zsh files from `/etc/zsh/custom/**/*.zsh` by uncommenting and activating the relevant block in `interactiveShellInit`, improving modularity and maintainability of shell configuration.