### PR TITLE
dependency: zoxide

### DIFF
--- a/asagi/home.nix
+++ b/asagi/home.nix
@@ -43,6 +43,7 @@
       tree
       wthrr
       yazi
+      zoxide
     ]
     ++ [
       pkgsUnstable.claude-code


### PR DESCRIPTION
This pull request adds a new package to the list of installed tools in the `asagi/home.nix` configuration. The change is minor and simply includes the `zoxide` utility to the user's environment.

https://github.com/ajeetdsouza/zoxide