### PR TITLE
feature: allow claude to edit and search

### DIFF
--- a/asagi/configs/claude/settings.json
+++ b/asagi/configs/claude/settings.json
@@ -2,18 +2,20 @@
   "permissions": {
     "allow": [
       "Bash(cat:*)",
-      "Bash(gh api:*)",
-      "Bash(git diff:*)",
+      "Bash(gh:*)",
+      "Bash(git:*)",
       "Bash(man:*)",
       "Bash(task:*)",
       "Bash(tree:*)",
       "Bash(which:*)",
+      "Edit(*)",
       "Glob",
       "Grep",
       "SlashCommand",
       "TodoWrite",
       "WebFetch",
-      "WebSearch"
+      "WebSearch",
+      "Write(*)",
     ],
     "deny": [
       "Read(.env)",
@@ -46,10 +48,10 @@
       "WebFetch(domain:github.com)"
     ],
     "ask": [
-      "Bash(gh:*)",
-      "Bash(git:*)",
-      "Edit(*)",
-      "Write(*)"
+      "Bash(git -rm:*)",
+      "Bash(git merge:*)",
+      "Bash(git push -f:*)",
+      "Bash(git revert:*)",
     ]
   },
 


### PR DESCRIPTION
This pull request updates the permissions configuration for the Claude integration in `asagi/configs/claude/settings.json`. The main changes refine which Bash commands and editing operations are allowed or require explicit approval, improving both security and usability.

**Permissions updates:**

* Broadened allowed Bash commands by replacing `Bash(gh api:*)` and `Bash(git diff:*)` with more general `Bash(gh:*)` and `Bash(git:*)`, and added `Edit(*)` and `Write(*)` to the allowed list.

**Approval requirements:**

* Removed blanket "ask" requirement for all `Bash(gh:*)`, `Bash(git:*)`, `Edit(*)`, and `Write(*)` commands, and instead specified that only potentially risky git operations (`git -rm`, `git merge`, `git push -f`, `git revert`) require explicit approval.