### PR TITLE
Fix nix-darwin build failure by updating llm-agents input

### DIFF
--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1774947294,
-        "narHash": "sha256-HQCV6dQQJk+4Ogox1LXhIUMtaFUeVy72LzY3HLyO5sE=",
+        "lastModified": 1775446641,
+        "narHash": "sha256-xzRYQF3iTdnjLnRDqLcud6bsBBth7jHqWXcY2/I13bY=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "c16f7573405eec513a201b4626aabcd1444a7382",
+        "rev": "cf24ebe96828b5c38fb0dbbbeed89f8d5397915f",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774610258,
-        "narHash": "sha256-HaThtroVD9wRdx7KQk0B75JmFcXlMUoEdDFNOMOlsOs=",
+        "lastModified": 1775126147,
+        "narHash": "sha256-J0dZU4atgcfo4QvM9D92uQ0Oe1eLTxBVXjJzdEMQpD0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "832efc09b4caf6b4569fbf9dc01bec3082a00611",
+        "rev": "8d8c1fa5b412c223ffa47410867813290cdedfef",
         "type": "github"
       },
       "original": {
@@ -240,11 +240,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773297127,
-        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "lastModified": 1775125835,
+        "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "rev": "75925962939880974e3ab417879daffcba36c4a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Background

`task apply` による nix-darwin ビルドが失敗するようになった。原因は `numtide/llm-agents.nix` フレークが提供する claude-code 2.1.88 のバイナリが、Google Cloud Storage の配布サーバーから削除されていたこと（HTTP 404）。

ビルドログ:
```
trying https://storage.googleapis.com/claude-code-dist-.../claude-code-releases/2.1.88/darwin-arm64/claude
curl: (22) The requested URL returned error: 404
error: cannot download claude from any mirror
```

claude-code は Anthropic が外部ホスティングでバイナリを配布しており、古いバージョンが予告なく削除されることがある。flake.lock でピン留めされたリビジョンが参照するバージョンが消えると、このようにビルドが壊れる。

## Approach

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: `nix flake update llm-agents` で input を更新 | 最小限の変更、上流の修正をそのまま取得 | llm-agents の他の依存も同時に更新される |
| B: claude-code パッケージだけ nixpkgs や独自 derivation に差し替え | llm-agents の他パッケージに影響なし | メンテナンスコスト増、llm-agents の利点を失う |

### 採用理由

選択肢 A を採用。llm-agents フレークは claude-code のバージョン追従を一元管理しており、input を更新するだけで最新の有効なバイナリ URL を取得できる。副次的に更新される flake-parts, treefmt-nix, nixpkgs（llm-agents 内部用）はいずれも llm-agents の内部依存であり、nix-darwin の直接的な動作には影響しない。

## What Changed

### llm-agents flake input の更新

- `nix-darwin/flake.lock` — `llm-agents` を `c16f757` → `cf24ebe` に更新。これにより claude-code が 2.1.88 → 2.1.92 に更新され、有効な配布 URL からバイナリを取得できるようになった。

付随して llm-agents の内部依存（flake-parts, treefmt-nix, nixpkgs）も更新されているが、これらは llm-agents のビルドインフラ用であり、nix-darwin 構成への直接的な影響はない。

## Tradeoffs and Limitations

- **llm-agents 全体の更新**: claude-code だけでなく gemini-cli 等の他パッケージも同時に更新される。今回は gemini-cli が 0.36.0 のまま変化なしであることを確認済み
- **再発リスク**: 配布サーバーからバイナリが削除されるたびに同様の問題が起きうる。根本的には llm-agents フレークの上流で対処が必要だが、現時点では定期的な `nix flake update` で対応する

## Testing

`nix build .#darwinConfigurations.shunsuke-darwin.system` でビルドが成功することを確認済み。`task apply`（sudo 必要）は手動で実行する。

## Review Guide

1. `nix-darwin/flake.lock` の diff を確認してください — llm-agents とその内部依存 3 つのハッシュ更新のみです

🤖 Generated with [Claude Code](https://claude.com/claude-code)