### PR TITLE
Add recommend-tasks hook for Task usage before Write/Edit

### DIFF
--- a/configs/claude/hooks/recommend-tasks.sh
+++ b/configs/claude/hooks/recommend-tasks.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# recommend-tasks.sh - PreToolUse hook for Claude Code
+# Sends a notify message before every Write/Edit call,
+# recommending Claude to use TaskCreate for progress tracking.
+
+set -euo pipefail
+
+input="$(cat)"
+
+tool_name="$(echo "$input" | jq -r '.tool_name // empty')"
+if [[ "$tool_name" != "Write" && "$tool_name" != "Edit" ]]; then
+  exit 0
+fi
+
+jq -n '{
+  "decision": "notify",
+  "message": "[TASK RECOMMENDATION] You are about to write or edit a file. If you have not created Tasks yet, use TaskCreate now to:\n1. Break down your work into trackable steps\n2. Mark tasks as in_progress before starting each step\n3. Mark tasks as completed when done\n\nThis helps the user understand your progress and ensures structured work."
+}'

--- a/configs/claude/hooks/recommend-tasks.sh
+++ b/configs/claude/hooks/recommend-tasks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # recommend-tasks.sh - PreToolUse hook for Claude Code
 # Sends a notify message before every Write/Edit call,
-# recommending Claude to use TaskCreate for progress tracking.
+# requiring Claude to use TaskCreate for progress tracking.
 
 set -euo pipefail
 
@@ -14,5 +14,5 @@ fi
 
 jq -n '{
   "decision": "notify",
-  "message": "[TASK RECOMMENDATION] You are about to write or edit a file. If you have not created Tasks yet, use TaskCreate now to:\n1. Break down your work into trackable steps\n2. Mark tasks as in_progress before starting each step\n3. Mark tasks as completed when done\n\nThis helps the user understand your progress and ensures structured work."
+  "message": "[MANDATORY ACTION REQUIRED] You MUST use TaskCreate before writing or editing files. If you have not created Tasks yet, stop and create them NOW.\n\n1. Break down your work into trackable steps with TaskCreate\n2. Mark tasks as in_progress before starting each step\n3. Mark tasks as completed when done\n\nDo NOT proceed with Write/Edit without Tasks."
 }'

--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -66,6 +66,15 @@
             "command": "$HOME/.claude/hooks/enforce-narrative-pr.sh"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/recommend-tasks.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/nix-darwin/modules/claude.nix
+++ b/nix-darwin/modules/claude.nix
@@ -30,5 +30,6 @@
     run install -Dm755 ${../../configs/claude/hooks/validate-bash.sh} $HOME/.claude/hooks/validate-bash.sh
     run install -Dm755 ${../../configs/claude/hooks/enforce-narrative-pr.sh} $HOME/.claude/hooks/enforce-narrative-pr.sh
     run install -Dm755 ${../../configs/claude/hooks/trigger-ci-fix.sh} $HOME/.claude/hooks/trigger-ci-fix.sh
+    run install -Dm755 ${../../configs/claude/hooks/recommend-tasks.sh} $HOME/.claude/hooks/recommend-tasks.sh
   '';
 }


### PR DESCRIPTION
## Background

Claude Code の Task ツール（TaskCreate / TaskUpdate / TaskList）は、複雑な作業を分割し進捗を可視化する重要な機能だが、Claude が Write/Edit に直行してしまい Task を使い忘れるケースがあった。作業の途中経過がユーザーから見えなくなり、何をしているか把握しづらくなる問題を解消したい。

## Approach

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: 毎回 notify（採用） | 状態管理不要、実装がシンプル | Write/Edit のたびにメッセージが出る |
| B: フラグファイルで状態管理 | Task 使用後はリマインドが消える | セッションをまたぐとフラグが残り、リマインドが出ないバグが発生する |
| C: SessionStart でフラグリセット + 有効期限 | セッション単位で正確に動く | 状態管理の複雑さが増す |

### 採用理由

選択肢 B では「前セッションのフラグが残りリマインドが出ない」というバグが不可避。C で解決可能だが、状態管理の複雑さに見合わない。A は毎回メッセージが出るが、`notify` decision はブロックしないため実害がなく、最もシンプルで壊れにくい。

## What Changed

### Task 利用推奨フックの追加

- `configs/claude/hooks/recommend-tasks.sh` — Write/Edit 実行前に `notify` を返す PreToolUse フックスクリプト（新規）
- `configs/claude/settings.json` — `Write|Edit` matcher で recommend-tasks.sh を呼び出す PreToolUse エントリを追加
- `nix-darwin/modules/claude.nix` — recommend-tasks.sh のデプロイ行を `claudeHooks` activation に追加

## Tradeoffs and Limitations

- **毎回 notify が出る**: Task を既に作成済みでもリマインドが飛ぶ。ただし `notify` はブロックしないので、Claude はメッセージを確認しつつそのまま作業を継続できる
- **強制力がない**: `reject` ではなく `notify` なので、Claude が無視する可能性はゼロではない。ただし reject にすると Task が不要な場面でも Write/Edit が止まってしまうため、推奨に留めた

## Testing

- フックスクリプトの構造は既存の `validate-bash.sh` / `trigger-ci-fix.sh` と同一パターン
- `jq -n` による JSON 出力の正当性はスクリプト単体で検証可能

## Review Guide

1. `configs/claude/hooks/recommend-tasks.sh` — フック本体（18行）。ロジックは tool_name の判定と jq 出力のみ
2. `configs/claude/settings.json` の diff — PreToolUse に `Write|Edit` matcher が追加されていることを確認
3. `nix-darwin/modules/claude.nix` の diff — install 行が1行追加されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)