### PR TITLE
Remove dot indicator from idle tab

### DIFF
--- a/nix-darwin/configs/wezterm/agent.lua
+++ b/nix-darwin/configs/wezterm/agent.lua
@@ -232,7 +232,7 @@ function M.setup()
     -- state == "Idle": green background, with ・ dot only if unseen
     local s = is_active and STYLE.Idle.active or STYLE.Idle.inactive
     if unseen_idle[tab_id] then
-      -- Reserve 2 chars for "・" prefix
+      -- Reserve 2 chars for "+ " prefix
       local available = max_width - 2
       if #title > available and available > 0 then
         title = title:sub(1, available)
@@ -241,7 +241,7 @@ function M.setup()
       return {
         { Background = { Color = s.bg } },
         { Foreground = { Color = s.dot } },
-        { Text = "・" },
+        { Text = "+ " },
         { Foreground = { Color = s.text } },
         { Text = title },
       }

--- a/nix-darwin/configs/wezterm/agent.lua
+++ b/nix-darwin/configs/wezterm/agent.lua
@@ -10,6 +10,12 @@ local CACHE_TTL = 3
 -- Per-pane claude state: pane_id -> "Running" | "Idle"
 local pane_states = {}
 
+-- Per-tab unseen completion tracking: tab_id -> true if idle & not yet viewed
+local unseen_idle = {}
+
+-- Previous tab states for detecting Running -> Idle transitions: tab_id -> "Running" | "Idle" | nil
+local prev_tab_states = {}
+
 -- Tab indicator colors (Tokyo Night Storm palette)
 local STYLE = {
   Running = {
@@ -162,12 +168,45 @@ end
 function M.setup()
   wezterm.on("update-right-status", function(_window, _pane)
     refresh_pane_states()
+
+    -- Detect Running -> Idle transitions on inactive tabs to mark as unseen
+    for _, mux_win in ipairs(wezterm.mux.all_windows()) do
+      local active_tab = mux_win:active_tab()
+      local active_tab_id = active_tab and active_tab:tab_id()
+      for _, tab in ipairs(mux_win:tabs()) do
+        local tab_id = tab:tab_id()
+        local current_state = resolve_tab_state(tab:panes())
+        local prev_state = prev_tab_states[tab_id]
+
+        if current_state == "Idle" and prev_state == "Running" and tab_id ~= active_tab_id then
+          unseen_idle[tab_id] = true
+        end
+
+        -- Clear unseen flag when user views the tab
+        if tab_id == active_tab_id then
+          unseen_idle[tab_id] = nil
+        end
+
+        -- Clear unseen flag if claude is no longer present
+        if not current_state then
+          unseen_idle[tab_id] = nil
+        end
+
+        prev_tab_states[tab_id] = current_state
+      end
+    end
   end)
 
   wezterm.on("format-tab-title", function(tab, _tabs, _panes, _config, _hover, max_width)
     local title = tab.active_pane.title
     local state = resolve_tab_state(tab.panes)
+    local tab_id = tab.tab_id
     local is_active = tab.is_active
+
+    -- Clear unseen flag when user views the tab
+    if is_active then
+      unseen_idle[tab_id] = nil
+    end
 
     if not state then
       return title
@@ -190,8 +229,24 @@ function M.setup()
       }
     end
 
-    -- state == "Idle": apply color only, no dot indicator
+    -- state == "Idle": green background, with ・ dot only if unseen
     local s = is_active and STYLE.Idle.active or STYLE.Idle.inactive
+    if unseen_idle[tab_id] then
+      -- Reserve 2 chars for "・" prefix
+      local available = max_width - 2
+      if #title > available and available > 0 then
+        title = title:sub(1, available)
+      end
+
+      return {
+        { Background = { Color = s.bg } },
+        { Foreground = { Color = s.dot } },
+        { Text = "・" },
+        { Foreground = { Color = s.text } },
+        { Text = title },
+      }
+    end
+
     return {
       { Background = { Color = s.bg } },
       { Foreground = { Color = s.text } },

--- a/nix-darwin/configs/wezterm/agent.lua
+++ b/nix-darwin/configs/wezterm/agent.lua
@@ -10,12 +10,6 @@ local CACHE_TTL = 3
 -- Per-pane claude state: pane_id -> "Running" | "Idle"
 local pane_states = {}
 
--- Per-tab unseen completion tracking: tab_id -> true if idle & not yet viewed
-local unseen_idle = {}
-
--- Previous tab states for detecting Running -> Idle transitions: tab_id -> "Running" | "Idle" | nil
-local prev_tab_states = {}
-
 -- Tab indicator colors (Tokyo Night Storm palette)
 local STYLE = {
   Running = {
@@ -168,45 +162,12 @@ end
 function M.setup()
   wezterm.on("update-right-status", function(_window, _pane)
     refresh_pane_states()
-
-    -- Detect Running -> Idle transitions on inactive tabs to mark as unseen
-    for _, mux_win in ipairs(wezterm.mux.all_windows()) do
-      local active_tab = mux_win:active_tab()
-      local active_tab_id = active_tab and active_tab:tab_id()
-      for _, tab in ipairs(mux_win:tabs()) do
-        local tab_id = tab:tab_id()
-        local current_state = resolve_tab_state(tab:panes())
-        local prev_state = prev_tab_states[tab_id]
-
-        if current_state == "Idle" and prev_state == "Running" and tab_id ~= active_tab_id then
-          unseen_idle[tab_id] = true
-        end
-
-        -- Clear unseen flag when user views the tab
-        if tab_id == active_tab_id then
-          unseen_idle[tab_id] = nil
-        end
-
-        -- Clear unseen flag if claude is no longer present
-        if not current_state then
-          unseen_idle[tab_id] = nil
-        end
-
-        prev_tab_states[tab_id] = current_state
-      end
-    end
   end)
 
   wezterm.on("format-tab-title", function(tab, _tabs, _panes, _config, _hover, max_width)
     local title = tab.active_pane.title
     local state = resolve_tab_state(tab.panes)
-    local tab_id = tab.tab_id
     local is_active = tab.is_active
-
-    -- Clear unseen flag when user views the tab
-    if is_active then
-      unseen_idle[tab_id] = nil
-    end
 
     if not state then
       return title
@@ -229,26 +190,13 @@ function M.setup()
       }
     end
 
-    -- state == "Idle"
-    if unseen_idle[tab_id] then
-      -- Reserve 2 chars for "・" prefix
-      local available = max_width - 2
-      if #title > available and available > 0 then
-        title = title:sub(1, available)
-      end
-
-      local s = is_active and STYLE.Idle.active or STYLE.Idle.inactive
-      return {
-        { Background = { Color = s.bg } },
-        { Foreground = { Color = s.dot } },
-        { Text = "・" },
-        { Foreground = { Color = s.text } },
-        { Text = title },
-      }
-    end
-
-    -- Idle and already seen: no indicator
-    return title
+    -- state == "Idle": apply color only, no dot indicator
+    local s = is_active and STYLE.Idle.active or STYLE.Idle.inactive
+    return {
+      { Background = { Color = s.bg } },
+      { Foreground = { Color = s.text } },
+      { Text = title },
+    }
   end)
 end
 


### PR DESCRIPTION
## Summary
- Idle状態のタブから「・」ドットインジケーターを削除し、背景色/テキスト色の変更のみを維持
- 不要になった `unseen_idle` / `prev_tab_states` の追跡ロジックを削除（59行削減）
- Running状態の「●」インジケーターはそのまま維持

## Test plan
- [ ] WezTermでClaudeを起動し、Running時に「●」が表示されることを確認
- [ ] Claudeがアイドル状態になった時、タブ背景色が緑系に変わり「・」が表示されないことを確認
- [ ] 非アクティブタブでも色が適切に変わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)