### PR TITLE
Add tab_max_width setting to WezTerm

### DIFF
--- a/nix-darwin/modules/wezterm.nix
+++ b/nix-darwin/modules/wezterm.nix
@@ -36,6 +36,7 @@
       -- Tab bar settings
       config.window_decorations = "RESIZE"
       config.show_new_tab_button_in_tab_bar = false
+      config.tab_max_width = 12
       config.colors = {
          tab_bar = {
            inactive_tab_edge = "none",


### PR DESCRIPTION
## Background

直近のタブインジケーター改善（#267, #268）により、タブにステータス情報（idle indicator など）を表示するようになった。タブ幅がコンテンツに応じて無制限に広がると、多数のタブを開いた際にタブバーが横に伸びすぎて視認性が下がる。タブ幅に上限を設けることで、タブバー全体のレイアウトを安定させる。

## Approach

WezTerm の組み込み設定 `tab_max_width` を使い、タブの最大幅を 12 文字に制限する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: `tab_max_width = 12` | 1行の設定追加で済む。WezTerm ネイティブの機能 | タブタイトルが長い場合に切り詰められる |
| B: カスタム format-tab-title で制御 | 表示内容を細かく制御できる | 既存の agent.lua との統合が複雑になる |

### 採用理由

既存のタブバー設定（`window_decorations`, `show_new_tab_button_in_tab_bar`）と同じ宣言的なスタイルで、1行で目的を達成できるため選択肢 A を採用した。

## What Changed

### タブ幅の上限設定

- `nix-darwin/modules/wezterm.nix` - タブバー設定セクションに `config.tab_max_width = 12` を追加

## Tradeoffs and Limitations

- **タイトル切り詰め**: 12文字を超えるタブタイトルは末尾が省略される。現在のタブ表示（プロセス名 + ステータスインジケーター）は短いため実用上問題ないが、長いパスを表示するケースでは情報が欠落する
- **固定値**: ウィンドウ幅に応じた動的な調整はしない。タブ数が極端に多い場合はスクロールが必要になる

## Testing

- `nix flake check` でビルドエラーがないことを確認
- WezTerm でタブを複数開き、タブ幅が制限されることを目視確認

## Review Guide

1. `nix-darwin/modules/wezterm.nix` の差分は1行のみ — タブバー設定セクション内の配置が適切か確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)