### PR TITLE
Fix unseen idle indicator not displaying in WezTerm tabs

### DIFF
--- a/nix-darwin/configs/wezterm/agent.lua
+++ b/nix-darwin/configs/wezterm/agent.lua
@@ -175,7 +175,14 @@ function M.setup()
       local active_tab_id = active_tab and active_tab:tab_id()
       for _, tab in ipairs(mux_win:tabs()) do
         local tab_id = tab:tab_id()
-        local current_state = resolve_tab_state(tab:panes())
+        -- tab:panes() returns Pane objects (method :pane_id()),
+        -- but resolve_tab_state expects PaneInformation (field .pane_id).
+        -- Convert to compatible format.
+        local panes_info = {}
+        for _, pane in ipairs(tab:panes()) do
+          table.insert(panes_info, { pane_id = pane:pane_id() })
+        end
+        local current_state = resolve_tab_state(panes_info)
         local prev_state = prev_tab_states[tab_id]
 
         if current_state == "Idle" and prev_state == "Running" and tab_id ~= active_tab_id then
@@ -229,7 +236,7 @@ function M.setup()
       }
     end
 
-    -- state == "Idle": green background, with ・ dot only if unseen
+    -- state == "Idle": green background, with + indicator only if unseen
     local s = is_active and STYLE.Idle.active or STYLE.Idle.inactive
     if unseen_idle[tab_id] then
       -- Reserve 2 chars for "+ " prefix


### PR DESCRIPTION
## Background

PR #268 で unseen idle インジケータ（非アクティブタブで Claude が Running → Idle に遷移したことを示す `+` マーク）を導入したが、実際にはインジケータが一切表示されない不具合があった。

## Approach

### 原因

`resolve_tab_state` 関数は `pane_info.pane_id` というフィールドアクセスで pane ID を取得する。この関数は2つの異なるコールサイトから呼ばれている:

| コールサイト | 渡されるオブジェクト | `.pane_id` の意味 | 結果 |
|---|---|---|---|
| `format-tab-title` | `PaneInformation` (struct) | フィールド → 数値が返る | 正常動作 |
| `update-right-status` | `Pane` (userdata) | メソッド → function が返る | `pane_states[function]` → 常に nil |

`update-right-status` 内で `resolve_tab_state` が常に nil を返すため、Running → Idle 遷移が検出されず、`unseen_idle` フラグが一度もセットされなかった。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|---|---|---|
| A: 呼び出し側で Pane → PaneInformation 形式に変換 | `resolve_tab_state` の変更不要、影響範囲が最小 | 変換の allocations が毎回発生 |
| B: `resolve_tab_state` を2つの型に対応させる | 呼び出し側の変更不要 | 型判定ロジックが増え関数の責務が曖昧になる |

### 採用理由

選択肢 A を採用。`update-right-status` は数秒に1回の頻度でしか発火しないため、小さなテーブル変換のコストは無視できる。`resolve_tab_state` のインターフェースを単純に保てる利点が上回る。

## What Changed

### Pane オブジェクトの型変換を追加

- `nix-darwin/configs/wezterm/agent.lua` — `update-right-status` ハンドラ内で `tab:panes()` が返す `Pane` オブジェクトを `{ pane_id = pane:pane_id() }` テーブルに変換してから `resolve_tab_state` に渡すようにした

## Tradeoffs and Limitations

- **毎回テーブルを生成**: ポーリングごとに小さなテーブルを生成するが、頻度が低い（3秒TTL）ため実用上問題なし
- **型の不一致が暗黙的**: WezTerm の Lua API は `Pane` と `PaneInformation` で同名フィールドのアクセス方法が異なるが、Lua の動的型付けによりエラーにならず nil が返る。静的チェックでは防げない種類のバグ

## Testing

WezTerm 上で以下を手動確認する:
- [ ] 非アクティブタブで Claude が Running → Idle に遷移したとき `+` が表示される
- [ ] アクティブタブに切り替えると `+` が消える
- [ ] Running 中のタブには従来通り `●` が表示される

## Review Guide

1. diff は `agent.lua` の1箇所のみ — `update-right-status` ハンドラ内の変換ロジックを確認してください
2. `resolve_tab_state` (L154-165) の `.pane_id` アクセスと、変換後のテーブルが整合していることを確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)