### PR TITLE
Remove mise from home-manager packages

### DIFF
--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -44,7 +44,6 @@
       hadolint
       hurl
       hyperfine
-      mise
       nerd-fonts.jetbrains-mono
       nixfmt-rfc-style
       npins


### PR DESCRIPTION
## Summary
- direnv (mise dependency) fails to build on current nixpkgs due to fish test timeout (`make: *** [GNUmakefile:150: test-fish] Killed: 9`)
- Remove mise to unblock `darwin-rebuild switch`

## Test plan
- [x] `nix build .#darwinConfigurations.shunsock-darwin.system` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)