### PR TITLE
add: nitter package to nix-darwin

### DIFF
--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -45,6 +45,7 @@
       hurl
       hyperfine
       nerd-fonts.jetbrains-mono
+      nitter
       nixfmt-rfc-style
       npins
       presenterm


### PR DESCRIPTION
## Background

nitter を macOS 開発環境に追加する。ユーザーからの直接の要望による。

## Approach

`nix-darwin/home.nix` の `home.packages` リストに `nitter` を追加した。nixpkgs に存在するパッケージであるため、宣言的に1行追加するだけで完結する。

## What Changed

### nitter パッケージの追加

- `nix-darwin/home.nix` - `home.packages` に `nitter` を追加（アルファベット順を維持）

## Testing

- `nix build .#darwinConfigurations.shunsock-darwin.system` でビルド成功を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)