### PR TITLE
add: PyCharm Community Edition to nix-darwin

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -90,6 +90,7 @@
                 "aquaskk"
                 "arc"
                 "docker-desktop"
+                "pycharm-ce"
                 "sf-symbols"
                 "steam"
                 "wezterm"


### PR DESCRIPTION
## Summary
- nix-darwin の Homebrew casks に `pycharm-ce` (PyCharm Community Edition) を追加

## Test plan
- [x] `nix build` でビルド成功を確認済み
- [ ] `task apply` で実機に適用して PyCharm CE がインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)