### PR TITLE
add: gc task for Nix store garbage collection

### DIFF
--- a/nix-darwin/Taskfile.yml
+++ b/nix-darwin/Taskfile.yml
@@ -41,3 +41,8 @@ tasks:
     desc: Format Nix Settings
     cmds:
       - nix fmt
+
+  gc:
+    desc: Garbage collect old Nix store paths (keep last 30 days)
+    cmds:
+      - nix-collect-garbage --delete-older-than 30d


### PR DESCRIPTION
## Summary
- Nix store の古いパスを削除する `task gc` を追加
- 30日より古い世代を `nix-collect-garbage --delete-older-than 30d` で削除する

## Test plan
- [ ] `task gc` が正常に実行できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)