### PR TITLE
fix: replace deprecated pycharm-ce with pycharm

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -90,7 +90,7 @@
                 "aquaskk"
                 "arc"
                 "docker-desktop"
-                "pycharm-ce"
+                "pycharm"
                 "sf-symbols"
                 "steam"
                 "wezterm"


### PR DESCRIPTION
## Summary
- Homebrew で `pycharm-ce` が deprecated になり 2026-12-08 に無効化予定
- 後継の `pycharm` cask に置き換え

## Test plan
- [ ] `task apply` が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)