### PR TITLE
add: typos spell checker

### DIFF
--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -51,6 +51,7 @@
       presenterm
       rustup
       tree
+      typos
       wthrr
       yazi
       zoxide

--- a/nix-os/home.nix
+++ b/nix-os/home.nix
@@ -36,6 +36,7 @@
       go-task
       ssm-session-manager-plugin
       tree
+      typos
       yazi
     ]
     ++ [


### PR DESCRIPTION
## Summary
- crate-ci/typos (source code spell checker) を nix-darwin と nix-os の両環境に追加
- nixpkgs の `pkgs.typos` (v1.39.2) を利用
- nix-darwin ビルド確認済み

## Test plan
- [ ] `task apply` (nix-darwin) で適用後、`typos --version` が実行できること
- [ ] nix-os 側でも `nixos-rebuild switch` 後に利用可能であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)