### PR TITLE
replace: pycharm cask with jetbrains-toolbox

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -90,7 +90,7 @@
                 "aquaskk"
                 "arc"
                 "docker-desktop"
-                "pycharm"
+                "jetbrains-toolbox"
                 "sf-symbols"
                 "steam"
                 "wezterm"


### PR DESCRIPTION
## Background

nix-darwin の Homebrew casks に PyCharm が単体で登録されていた。JetBrains IDE を複数使う場合や、IDE のバージョン管理・アップデートを一元化したい場合、個別 cask よりも JetBrains Toolbox 経由での管理が現在の定番となっている。Toolbox を入れれば PyCharm を含む全 JetBrains IDE をツール内からインストール・管理できるため、cask 側は Toolbox だけで十分になる。

## Approach

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: pycharm を jetbrains-toolbox に置換 | IDE 管理を Toolbox に一元化でき、将来 IDE を追加しても flake.nix を変更不要 | PyCharm のインストールが Nix 管理外（Toolbox 内での手動操作）になる |
| B: pycharm を残したまま jetbrains-toolbox を追加 | 既存の PyCharm が維持される | 同じ IDE が Homebrew cask と Toolbox で二重管理になり競合の恐れがある |

### 採用理由

Toolbox は JetBrains 公式の IDE マネージャであり、バージョン管理・自動アップデート・複数 IDE の切り替えを担う。pycharm cask を残すと二重管理になるため、置換が最もシンプル。

## What Changed

### Homebrew cask の入れ替え

- `nix-darwin/flake.nix` — casks リストの `"pycharm"` を `"jetbrains-toolbox"` に変更

## Tradeoffs and Limitations

- **Nix 管理外の IDE インストール**: Toolbox 内での IDE 選択・インストールは手動操作になるため、完全な宣言的管理からは外れる。ただし Toolbox 自体は Nix (Homebrew cask) で管理されるため、マシンセットアップ時に Toolbox までは自動で入る。
- **既存 PyCharm の扱い**: apply 後、Homebrew が既存の PyCharm cask をアンインストールする可能性がある。Toolbox から再インストールすれば設定は JetBrains アカウント同期で復元可能。

## Testing

- `nix build .#darwinConfigurations.shunsock-darwin.system` でビルド成功を確認済み
- apply は sudo が必要なため手動で実行する

## Review Guide

1. `nix-darwin/flake.nix` の casks リスト差分（1行の置換）を確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)