### PR TITLE
add: Claude Code statusline and vim editor mode

### DIFF
--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -2,7 +2,8 @@
   "env": {
     "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
     "BASH_DEFAULT_TIMEOUT_MS": "180000",
-    "MAX_THINKING_TOKENS": "10000"
+    "MAX_THINKING_TOKENS": "10000",
+    "CLAUDE_CODE_NO_FLICKER": "1"
   },
   "permissions": {
     "allow": [

--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -100,5 +100,11 @@
   "skipDangerousModePermissionPrompt": true,
   "enabledPlugins": {
     "document-skills@anthropic-agent-skills": true
+  },
+  "editorMode": "vim",
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh",
+    "refreshInterval": 10
   }
 }

--- a/configs/claude/statusline.sh
+++ b/configs/claude/statusline.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Claude Code statusline script
+# Displays: model | context usage bar | cost | duration | git branch
+
+input=$(cat)
+
+# Model
+MODEL=$(echo "$input" | jq -r '.model.display_name // "Claude"')
+
+# Context window usage
+PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+BAR_WIDTH=15
+FILLED=$((PCT * BAR_WIDTH / 100))
+EMPTY=$((BAR_WIDTH - FILLED))
+BAR=""
+if [ "$FILLED" -gt 0 ]; then
+  printf -v FILL "%${FILLED}s"
+  BAR="${FILL// /▓}"
+fi
+if [ "$EMPTY" -gt 0 ]; then
+  printf -v PAD "%${EMPTY}s"
+  BAR="${BAR}${PAD// /░}"
+fi
+
+# Color context bar based on usage
+if [ "$PCT" -ge 80 ]; then
+  CTX_COLOR="\033[31m" # red
+elif [ "$PCT" -ge 50 ]; then
+  CTX_COLOR="\033[33m" # yellow
+else
+  CTX_COLOR="\033[32m" # green
+fi
+RESET="\033[0m"
+
+# Cost
+COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
+COST_FMT=$(printf '$%.2f' "$COST")
+
+# Duration
+DURATION_MS=$(echo "$input" | jq -r '.cost.total_duration_ms // 0')
+DURATION_SEC=$((DURATION_MS / 1000))
+MINS=$((DURATION_SEC / 60))
+SECS=$((DURATION_SEC % 60))
+
+# Git branch
+CWD=$(echo "$input" | jq -r '.workspace.current_dir // "."')
+BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null)
+if [ -n "$BRANCH" ]; then
+  GIT_PART=" | ${BRANCH}"
+else
+  GIT_PART=""
+fi
+
+printf "%b" "${MODEL} | ${CTX_COLOR}${BAR} ${PCT}%%${RESET} | ${COST_FMT} | ${MINS}m${SECS}s${GIT_PART}\n"

--- a/nix-darwin/modules/claude.nix
+++ b/nix-darwin/modules/claude.nix
@@ -24,6 +24,11 @@
     run install -Dm644 ${../../configs/claude/settings.json} $HOME/.claude/settings.json
   '';
 
+  # statusline スクリプトをコピーとして配置（実行権限が必要）
+  home.activation.claudeStatusline = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    run install -Dm755 ${../../configs/claude/statusline.sh} $HOME/.claude/statusline.sh
+  '';
+
   # hook スクリプトをコピーとして配置（実行権限が必要）
   home.activation.claudeHooks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     run mkdir -p $HOME/.claude/hooks


### PR DESCRIPTION
## Summary

- Claude Code のステータスライン（画面下部の常時表示バー）を追加。モデル名・コンテキスト使用率（色付きプログレスバー）・セッションコスト・経過時間・git ブランチを表示する
- エディタモードを vim に変更。入力欄で hjkl 移動やテキストオブジェクト操作が可能になる
- statusline.sh を Nix で `~/.claude/statusline.sh` にデプロイする activation を追加

## Changed files

| File | Change |
|------|--------|
| `configs/claude/statusline.sh` | 新規: ステータスラインスクリプト |
| `configs/claude/settings.json` | `editorMode: "vim"` と `statusLine` 設定を追加 |
| `nix-darwin/modules/claude.nix` | statusline.sh のデプロイ activation を追加 |

## Test plan

- [ ] `task apply` で nix-darwin を適用し、`~/.claude/statusline.sh` が配置されることを確認
- [ ] Claude Code を再起動し、画面下部にステータスラインが表示されることを確認
- [ ] vim モードが有効になり、NORMAL/INSERT モードが切り替えられることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)