### PR TITLE
fix: avoid double % in statusline percentage display

### DIFF
--- a/configs/claude/statusline.sh
+++ b/configs/claude/statusline.sh
@@ -51,4 +51,4 @@ else
   GIT_PART=""
 fi
 
-printf "%b" "${MODEL} | ${CTX_COLOR}${BAR} ${PCT}%%${RESET} | ${COST_FMT} | ${MINS}m${SECS}s${GIT_PART}\n"
+printf "%b" "${MODEL} | ${CTX_COLOR}${BAR} ${PCT}%${RESET} | ${COST_FMT} | ${MINS}m${SECS}s${GIT_PART}\n"


### PR DESCRIPTION
## Summary
- statusline の context 使用率表示が `0%%` のように `%` が2つ表示される不具合を修正
- `printf "%b" "...${PCT}%%..."` の `%%` はフォーマット文字列ではなく引数側にあったため、`%b` ではエスケープされずそのまま2文字出力されていた

## Background
`printf` の `%%` 表記はフォーマット文字列内でのみ `%` 1つに変換される。`printf "%b" "$arg"` のように `$arg` を引数として渡す場合、`%b` はバックスラッシュエスケープ (`\033` など色コード) を解釈するが、`%%` の処理は行わない。よって引数中の `%%` は2文字のまま出力されていた。

修正後は引数内に直接 `%` を1文字書いている (`%b` の引数は printf のフォーマット解釈を受けないため安全)。

## Test plan
- [x] サンプル JSON を流し込んで `42%` のように `%` が1つだけ表示されることを確認