### PR TITLE
add: secret scanners (gitleaks + trufflehog) with samoyed pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ result
 
 # Tailscale
 /etc/tailscale/authkey
+
+# samoyed (git hooks manager) — wrappers are generated, not tracked
+.samoyed/_/

--- a/.samoyed/pre-commit
+++ b/.samoyed/pre-commit
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# Block staged secrets at commit time. Bypass: SAMOYED=0 git commit ...
+set -eu
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "gitleaks not found in PATH; run 'darwin-rebuild switch' or 'nixos-rebuild switch' first." >&2
+  exit 1
+fi
+exec gitleaks protect --staged --redact --verbose

--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -80,6 +80,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -193,16 +211,88 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
         "llm-agents": "llm-agents",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "samoyed": "samoyed"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1758422215,
+        "narHash": "sha256-JvF5SXhp1wBHbfEVAWgJCDVSO8iknfDqXfqMch5YWg0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6f3988eb5885f1e2efa874a480d91de09a7f9f0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "samoyed": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1774535927,
+        "narHash": "sha256-yIUSQryRWRo65LWc+yzDwhj//K0EDxhim8tBmwV7WY0=",
+        "owner": "espiria",
+        "repo": "samoyed",
+        "rev": "93939e4092fdd7a8097eb91037e956f0c435264b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "espiria",
+        "repo": "samoyed",
+        "type": "github"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -9,6 +9,10 @@
     home-manager.url = "github:nix-community/home-manager/release-25.11";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     llm-agents.url = "github:numtide/llm-agents.nix";
+    samoyed = {
+      url = "github:espiria/samoyed";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -19,6 +23,7 @@
       nix-darwin,
       home-manager,
       llm-agents,
+      samoyed,
       ...
     }:
     let
@@ -36,6 +41,7 @@
         };
       };
       pkgsLlmAgents = llm-agents.packages.${system};
+      samoyedPkg = samoyed.packages.${system}.default;
 
       # thoughtbot/complexity: cognitive complexity measurement tool
       complexity = pkgs.rustPlatform.buildRustPackage rec {
@@ -109,6 +115,7 @@
                 inherit pkgsUnstable;
                 inherit pkgsLlmAgents;
                 inherit complexity;
+                inherit samoyedPkg;
               };
 
               users.shunsock = import ./home.nix;

--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -4,6 +4,7 @@
   pkgsUnstable,
   pkgsLlmAgents,
   complexity,
+  samoyedPkg,
   lib,
   ...
 }:
@@ -39,6 +40,7 @@
       gh
       ghq
       git
+      gitleaks
       go-task
       hackgen-nf-font
       hadolint
@@ -51,6 +53,7 @@
       presenterm
       rustup
       tree
+      trufflehog
       typos
       wthrr
       yazi
@@ -62,5 +65,6 @@
       pkgsUnstable.google-cloud-sdk
       pkgsUnstable.gws
       pkgsLlmAgents.gemini-cli
+      samoyedPkg
     ];
 }

--- a/nix-os/flake.lock
+++ b/nix-os/flake.lock
@@ -80,6 +80,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -187,6 +205,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "noctalia": {
       "inputs": {
         "nixpkgs": [
@@ -213,10 +247,66 @@
         "llm-agents": "llm-agents",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "noctalia": "noctalia"
+        "noctalia": "noctalia",
+        "samoyed": "samoyed"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1758422215,
+        "narHash": "sha256-JvF5SXhp1wBHbfEVAWgJCDVSO8iknfDqXfqMch5YWg0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6f3988eb5885f1e2efa874a480d91de09a7f9f0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "samoyed": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1774535927,
+        "narHash": "sha256-yIUSQryRWRo65LWc+yzDwhj//K0EDxhim8tBmwV7WY0=",
+        "owner": "espiria",
+        "repo": "samoyed",
+        "rev": "93939e4092fdd7a8097eb91037e956f0c435264b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "espiria",
+        "repo": "samoyed",
+        "type": "github"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/nix-os/flake.nix
+++ b/nix-os/flake.nix
@@ -11,6 +11,10 @@
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
     llm-agents.url = "github:numtide/llm-agents.nix";
+    samoyed = {
+      url = "github:espiria/samoyed";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -21,6 +25,7 @@
       home-manager,
       noctalia,
       llm-agents,
+      samoyed,
       ...
     }:
     let
@@ -38,6 +43,7 @@
         };
       };
       pkgsLlmAgents = llm-agents.packages.${system};
+      samoyedPkg = samoyed.packages.${system}.default;
 
       # thoughtbot/complexity: cognitive complexity measurement tool
       complexity = pkgs.rustPlatform.buildRustPackage rec {
@@ -73,6 +79,7 @@
                   inherit pkgsUnstable;
                   inherit pkgsLlmAgents;
                   inherit complexity;
+                  inherit samoyedPkg;
                 };
 
                 users.shunsock = import ./home.nix;

--- a/nix-os/home.nix
+++ b/nix-os/home.nix
@@ -4,6 +4,7 @@
   pkgsUnstable,
   pkgsLlmAgents,
   complexity,
+  samoyedPkg,
   lib,
   ...
 }:
@@ -33,14 +34,17 @@
     [
       fastfetch
       gh
+      gitleaks
       go-task
       ssm-session-manager-plugin
       tree
+      trufflehog
       typos
       yazi
     ]
     ++ [
       complexity
       pkgsLlmAgents.claude-code
+      samoyedPkg
     ];
 }


### PR DESCRIPTION
## Summary

- gitleaks と trufflehog を nix-darwin / nix-os の `home.packages` に追加
- samoyed (Rust 製 git hooks マネージャ) を upstream flake から取り込み (`llm-agents` と同じ入力パターン) し、両ホストにインストール
- このリポジトリ用に `.samoyed/pre-commit` を追加。`gitleaks protect --staged --redact --verbose` を起動し、コミット直前に staged 差分を検査

## Why

シークレット流出防止の役割分担:
- **gitleaks (pre-commit)**: 「これからの混入」をローカルで止める。`--staged` で高速、`--redact` でログに鍵生値を残さない
- **TruffleHog (手動)**: 過去の履歴で「今も生きている」鍵を `trufflehog git file://. --only-verified` で炙り出す高シグナル運用ツール

CI はこのリポジトリには導入しない。samoyed を採用した理由は単一バイナリで Python `pre-commit` フレームワークを置き換えられるため。

## Bootstrap (one-time per checkout)

```sh
darwin-rebuild switch --flake .#shunsock-darwin   # or nixos-rebuild switch
samoyed init   # creates .samoyed/_/ wrappers and sets core.hooksPath
```

`SAMOYED=0 git commit ...` が緊急時のバイパス。

## Test plan

- [ ] `task apply` (darwin) / `nixos-rebuild switch` 後、`which gitleaks trufflehog samoyed` がそれぞれパスを返す
- [ ] `samoyed init` 実行後、`git config core.hooksPath` が `.samoyed/_/` を指す
- [ ] 偽の AWS キー (`AKIAIOSFODNN7EXAMPLE`) を任意のテキストファイルに足して `git add && git commit` → フックが abort する
- [ ] `SAMOYED=0 git commit ...` でバイパスできる
- [ ] `trufflehog git file://. --only-verified` がエラーなく完走する

🤖 Generated with [Claude Code](https://claude.com/claude-code)