### PR TITLE
fix(nix-darwin): bypass samoyed flake to dodge apple_sdk_11_0 breakage

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -41,7 +41,26 @@
         };
       };
       pkgsLlmAgents = llm-agents.packages.${system};
-      samoyedPkg = samoyed.packages.${system}.default;
+      # samoyed の上流 flake は古い rust-overlay と darwin.apple_sdk.frameworks.* に依存しており、
+      # nixpkgs 25.11 では (a) legacy stub 削除で評価エラー、(b) rust-overlay 経由の rust-src が
+      # 拡張子を持たないソースとして fetch され unpackPhase に失敗する。
+      # よって上流の packages.default は使わず、ソースだけ拝借して nixpkgs の rustPlatform で
+      # 自前ビルドする (Apple framework は現行 Darwin stdenv が自動供給するため省略可)。
+      samoyedPkg = pkgs.rustPlatform.buildRustPackage {
+        pname = "samoyed";
+        version = "0.2.0";
+        src = samoyed;
+        cargoLock = {
+          lockFile = "${samoyed}/Cargo.lock";
+        };
+        nativeBuildInputs = [ pkgs.pkg-config ];
+        buildInputs = [ pkgs.openssl ];
+        OPENSSL_DIR = "${pkgs.openssl.dev}";
+        OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+        OPENSSL_INCLUDE_DIR = "${pkgs.openssl.dev}/include";
+        # 内部テストは git init を sandbox 内で実行し失敗するため、ビルド時はスキップする。
+        doCheck = false;
+      };
 
       # thoughtbot/complexity: cognitive complexity measurement tool
       complexity = pkgs.rustPlatform.buildRustPackage rec {


### PR DESCRIPTION
## 背景

`task apply` (= `sudo darwin-rebuild switch --flake .#shunsock-darwin`) が以下のエラーで失敗するようになっていた。

```
error: darwin.apple_sdk_11_0 has been removed as it was a legacy compatibility stub;
       see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks> for migration instructions
```

`--show-trace` で追うと、終端の評価対象は `apple_sdk.frameworks.Security`。これは `samoyed` 上流 flake が `buildInputs` に `darwin.apple_sdk.frameworks.Security` / `SystemConfiguration` を直書きしているため。`samoyed.inputs.nixpkgs.follows = "nixpkgs"` を経由して nixpkgs 25.11 にぶつけた結果、これらが legacy stub として削除されていて throw する。

## 試したこと

1. `overrideAttrs` で `buildInputs` を openssl だけに差し替える方針
   - 評価エラーは消えた
   - しかし上流 flake が pin している rust-overlay (`6f3988eb`, 2025-09-21) が rust-src を拡張子なしの `unknown` で fetch し、現行 stdenv の `unpackPhase` が「do not know how to unpack source archive」で死ぬ
2. **採用案**: 上流の `packages.default` には触れず、`samoyed` のソースだけ拝借して nixpkgs 25.11 同梱の `rustPlatform.buildRustPackage` で自前ビルド
   - 古い rust-overlay も apple_sdk スタブも経由しなくなる
   - Apple frameworks は現行 Darwin stdenv が自動供給するので buildInputs からは省略
   - 内部テストは `git init` を sandbox 内で叩いて落ちるので `doCheck = false`

## 確認

- `nix build .#darwinConfigurations.shunsock-darwin.system --no-link` → 成功
- `nix flake check` → all checks passed
- `task apply` (= sudo darwin-rebuild switch) はユーザー側で実行

## トレードオフ

- 上流 flake の独自パッチや devShell 設定からは離れたが、CLI として使う分には支障なし
- 上流が apple_sdk 周りを修正したらこのオーバーライドは戻して良い

🤖 Generated with [Claude Code](https://claude.com/claude-code)