### PR TITLE
feat(nix-darwin): add davinci-resolve cask

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -114,6 +114,7 @@
               casks = [
                 "aquaskk"
                 "arc"
+                "davinci-resolve"
                 "docker-desktop"
                 "jetbrains-toolbox"
                 "sf-symbols"


### PR DESCRIPTION
## Summary
- nix-darwin の Homebrew casks に `davinci-resolve` (無料版) を追加

## Test plan
- [x] `nix flake check` パス
- [ ] `task apply` で実際にインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)