### PR TITLE
fix(nix-darwin): remove non-existent davinci-resolve cask

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -114,7 +114,6 @@
               casks = [
                 "aquaskk"
                 "arc"
-                "davinci-resolve"
                 "docker-desktop"
                 "jetbrains-toolbox"
                 "sf-symbols"


### PR DESCRIPTION
## 背景

`task apply` 実行時、`brew bundle` が `davinci-resolve` を取得しようとして失敗していた。

```
Fetching davinci-resolve
Error: No available formula with the name "davinci-resolve".
`brew bundle` failed! Failed to fetch davinci-resolve
```

直前のコミット (a75e80f) で casks リストに追加されたが、実際には Homebrew に DaVinci Resolve の cask は存在しない。Blackmagic Design 配布物は登録ダウンロード形式のため Homebrew では扱われていない。

確認手順:
- `brew info --cask davinci-resolve` → `Error: Cask 'davinci-resolve' is unavailable`
- `curl https://formulae.brew.sh/api/cask/davinci-resolve.json` → 404
- 全 cask token を `davinci` / `blackmagic` / `resolve` で grep してもヒットなし

## 変更

`nix-darwin/flake.nix` の casks リストから `davinci-resolve` を削除する。DaVinci Resolve 本体は https://www.blackmagicdesign.com/products/davinciresolve から手動でダウンロードする運用に戻す。

## トレードオフ

- 宣言的管理から外れるが、そもそも Homebrew で配布されていないため Nix Darwin で記述する手段がない
- 代替として `homebrew-cask-versions` などの非公式 tap が存在するか検討したが、公式に存在する cask が見つからず断念

## Test plan

- [x] flake.nix から `davinci-resolve` を削除
- [ ] ローカルで `task apply` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)