### PR TITLE
feat(nix-darwin): homebrew onActivation で cleanup zap を有効化

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -76,6 +76,15 @@
           {
             homebrew = {
               enable = true;
+              # Nix から削除したパッケージは activation 時に自動アンインストールする。
+              # casks は関連ファイルまで削除する zap を採用 (brew は完全に Nix で一元管理)。
+              onActivation = {
+                cleanup = "zap";
+                # カタログ (formula/cask 定義) は最新化するが、
+                # インストール済みパッケージは固定して再現性を優先する。
+                autoUpdate = true;
+                upgrade = false;
+              };
               taps = [
                 "steipete/tap"
                 "Warashi/tap"


### PR DESCRIPTION
## 背景

Homebrew パッケージを Nix (`flake.nix`) で宣言管理しているが、これまで `homebrew.onActivation` を未設定だったため、**Nix の宣言から削除しても実体がアンインストールされず手元に残る**状態だった。Homebrew を完全に Nix で一元管理する方針のため、宣言を削除したら activation 時に自動で消えるようにしたい。

## 変更内容

`nix-darwin/flake.nix` の `homebrew` に `onActivation` を追加した。

```nix
onActivation = {
  cleanup = "zap";
  autoUpdate = true;
  upgrade = false;
};
```

| オプション | 値 | 意図 |
|-----------|----|----|
| `cleanup` | `"zap"` | Brewfile にないパッケージをアンインストール。cask は関連ファイルまで削除する |
| `autoUpdate` | `true` | formula/cask のカタログ (定義) を activation 時に最新化する |
| `upgrade` | `false` | インストール済みパッケージは固定し、勝手にバージョンを上げない |

## 意思決定 / トレードオフ

- **なぜ `zap` か (`uninstall` ではなく)**: brew を完全に Nix 管理し、手動 `brew install` を行わない運用のため、cask の関連ファイルまで削除する `zap` でも巻き込み事故が起きない。より徹底したクリーンアップを選択した。
- **なぜ `autoUpdate = true` / `upgrade = false` か**: 新規インストール時は最新版を取得しつつ、既存パッケージは固定することで再現性を優先する。`upgrade = true` だと apply のたびにバージョンが動き、宣言的構成の再現性が損なわれるため避けた。

## 既知の制約

- `masApps` は本設定 (`uninstall`/`zap`) でも自動アンインストールされない (Homebrew Bundle 側の制約)。本リポジトリでは `masApps` を未使用のため影響なし。

## 検証

- `nix build .#darwinConfigurations.shunsock-darwin.system` が成功することを確認済み。
- 実際の反映 (`task apply` / `darwin-rebuild switch`) は sudo が必要なため手元で実行する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)