### PR TITLE
fix(antigravity): rename package attr to antigravity-cli

### DIFF
--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -62,6 +62,6 @@
       pkgsLlmAgents.claude-code
       pkgsUnstable.google-cloud-sdk
       pkgsUnstable.gws
-      pkgsLlmAgents.antigravity
+      pkgsLlmAgents.antigravity-cli
     ];
 }


### PR DESCRIPTION
## 背景

`nix build` のたびに以下の警告が出ていた:

```
'antigravity' has been renamed to 'antigravity-cli'
```

`numtide/llm-agents.nix` 側でパッケージ `antigravity` が `antigravity-cli` にリネームされたため、旧名を参照していた `home.nix` で deprecation 警告が発生していた。

## 変更

- `nix-darwin/home.nix`: `pkgsLlmAgents.antigravity` → `pkgsLlmAgents.antigravity-cli`

新名のパッケージ実体は `antigravity-cli-1.0.6` で確認済み。設定ファイルの配置先 (`~/.gemini/antigravity-cli`) は元から新名に揃っていたため変更不要。

## 検証

- `nix build .#darwinConfigurations.shunsock-darwin.system` がリネーム警告なしで成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)