### PR TITLE
chore(nix-darwin): remove unused homebrew tap Warashi/tap

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -87,7 +87,6 @@
               };
               taps = [
                 "steipete/tap"
-                "Warashi/tap"
               ];
               brews = [
                 "colima"


### PR DESCRIPTION
## 概要

`nix-darwin/flake.nix` の homebrew 設定から、未使用の tap `Warashi/tap` を削除する。

## 背景

`homebrew.taps` に `steipete/tap` と `Warashi/tap` の2つが定義されていたが、`Warashi/tap` を参照する brew / cask が存在しなかった。

| tap | 利用状況 |
|-----|---------|
| `steipete/tap` | ✅ 使用中 — `steipete/tap/gogcli` (brews) が依存 |
| `Warashi/tap` | ❌ 未使用 — 参照する brew / cask が無い |

`onActivation.cleanup = "zap"` により brew を Nix で一元管理している方針のため、未使用の tap は削除しておく。

## 検証

- `nix flake check` → all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)