### PR TITLE
fix(nix-darwin): run rebuild via nix run, split build/switch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,10 @@ task update    # Update flake dependencies
 task validate  # Comprehensive validation (build + check)
 
 # Direct commands (if task fails)
-sudo darwin-rebuild switch --flake .#shunsock-darwin
+# Build as the current user, then switch with sudo via the prebuilt binary
+# (avoids running Nix evaluation under sudo).
+nix run github:LnL7/nix-darwin -- build --flake .#shunsock-darwin
+sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin
 nix build .#darwinConfigurations.shunsock-darwin.system
 nix flake check
 nix flake update

--- a/nix-darwin/CLAUDE.md
+++ b/nix-darwin/CLAUDE.md
@@ -13,16 +13,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Comprehensive validation**: `task validate`
 
 ### Direct Commands (if needed)
-- **Install nix-darwin system-wide**: `nix run nix-darwin -- switch --flake .#shunsock-darwin`
-- **Apply configuration**: `darwin-rebuild switch --flake .#shunsock-darwin`
-- **Build configuration**: `nix build .#darwinConfigurations.shunsock-darwin.system`
+Build as the current user, then switch with sudo via the prebuilt binary. This
+avoids running Nix evaluation under sudo (which loses the user's nix config/auth
+and produces root-owned cache):
+- **Build configuration (apply step 1)**: `nix run github:LnL7/nix-darwin -- build --flake .#shunsock-darwin`
+- **Apply configuration (apply step 2)**: `sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin`
+- **Build for validation only**: `nix build .#darwinConfigurations.shunsock-darwin.system`
 - **Check flake**: `nix flake check`
 - **Update flake inputs**: `nix flake update`
 
 ### Installation Notes
 - **First time setup**: Run `task init` to install nix-darwin system-wide
 - **After init**: The `darwin-rebuild` command will be available in your PATH
-- **Subsequent updates**: Use `task apply` or `sudo darwin-rebuild switch --flake .#shunsock-darwin`
+- **Subsequent updates**: Use `task apply` (builds as user, then `sudo ./result/sw/bin/darwin-rebuild switch`)
 - **Claude Code Limitation**: Commands requiring sudo cannot be executed by Claude Code and must be run manually in terminal
 
 ## Architecture

--- a/nix-darwin/README.md
+++ b/nix-darwin/README.md
@@ -88,7 +88,10 @@ task validate
 
 ```bash
 # Apply configuration changes
-sudo darwin-rebuild switch --flake .#shunsock-darwin
+# Build as the current user, then switch with sudo via the prebuilt binary
+# (avoids running Nix evaluation under sudo).
+nix run github:LnL7/nix-darwin -- build --flake .#shunsock-darwin
+sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin
 
 # Build configuration (test without applying)
 nix build .#darwinConfigurations.shunsock-darwin.system

--- a/nix-darwin/Taskfile.yml
+++ b/nix-darwin/Taskfile.yml
@@ -5,7 +5,10 @@ tasks:
     desc: Initialize the project by installing nix-darwin system-wide
     cmds:
       - /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-      - sudo nix run --extra-experimental-features nix-command --extra-experimental-features flakes nix-darwin -- switch --flake .#shunsock-darwin
+      # Build as the current user (uses the user's nix config/cache/auth), then
+      # apply with sudo using the prebuilt binary so root never re-evaluates the flake.
+      - nix run --extra-experimental-features "nix-command flakes" github:LnL7/nix-darwin -- build --flake .#shunsock-darwin
+      - sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin
       - echo "nix-darwin has been installed system-wide. darwin-rebuild command is now available."
     status:
       - which darwin-rebuild
@@ -14,7 +17,10 @@ tasks:
     desc: Apply the configuration with darwin-rebuild
     cmds:
       - bash script/remove_backup.sh
-      - sudo darwin-rebuild switch --flake .#shunsock-darwin
+      # Build as the current user, then switch with sudo via the prebuilt darwin-rebuild.
+      # This avoids running Nix evaluation under sudo (lost user config/auth, root-owned cache).
+      - nix run github:LnL7/nix-darwin -- build --flake .#shunsock-darwin
+      - sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin
 
   build:
     desc: Build and validate configuration without applying

--- a/nix-darwin/Taskfile.yml
+++ b/nix-darwin/Taskfile.yml
@@ -15,17 +15,20 @@ tasks:
 
   apply:
     desc: Apply the configuration with darwin-rebuild
+    deps:
+      - build
     cmds:
       - bash script/remove_backup.sh
-      # Build as the current user, then switch with sudo via the prebuilt darwin-rebuild.
-      # This avoids running Nix evaluation under sudo (lost user config/auth, root-owned cache).
-      - nix run github:LnL7/nix-darwin -- build --flake .#shunsock-darwin
+      # `build` (dep) produces ./result as the current user; switch with sudo via the
+      # prebuilt darwin-rebuild so root never re-evaluates the flake.
       - sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin
 
   build:
     desc: Build and validate configuration without applying
     cmds:
-      - nix build .#darwinConfigurations.shunsock-darwin.system
+      # Build the system closure as the current user. ./result contains the prebuilt
+      # darwin-rebuild, which `apply` reuses to switch under sudo without re-evaluating.
+      - nix run github:LnL7/nix-darwin -- build --flake .#shunsock-darwin
 
   check:
     desc: Validate flake configuration

--- a/nix-darwin/Taskfile.yml
+++ b/nix-darwin/Taskfile.yml
@@ -5,58 +5,49 @@ tasks:
     desc: Initialize the project by installing nix-darwin system-wide
     cmds:
       - /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-      # Build as the current user (uses the user's nix config/cache/auth), then
-      # apply with sudo using the prebuilt binary so root never re-evaluates the flake.
-      - nix run --extra-experimental-features "nix-command flakes" github:LnL7/nix-darwin -- build --flake .#shunsock-darwin
-      - sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin
-      - echo "nix-darwin has been installed system-wide. darwin-rebuild command is now available."
+      - bash script/entry_point/init.sh
     status:
       - which darwin-rebuild
 
   apply:
     desc: Apply the configuration with darwin-rebuild
-    deps:
-      - build
     cmds:
       - bash script/remove_backup.sh
-      # `build` (dep) produces ./result as the current user; switch with sudo via the
-      # prebuilt darwin-rebuild so root never re-evaluates the flake.
-      - sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin
+      - bash script/entry_point/build.sh
+      - bash script/entry_point/apply.sh
 
   build:
     desc: Build and validate configuration without applying
     cmds:
-      # Build the system closure as the current user. ./result contains the prebuilt
-      # darwin-rebuild, which `apply` reuses to switch under sudo without re-evaluating.
-      - nix run github:LnL7/nix-darwin -- build --flake .#shunsock-darwin
+      - bash script/entry_point/build.sh
 
   check:
     desc: Validate flake configuration
     cmds:
-      - nix flake check
+      - bash script/entry_point/check.sh
 
   update:
     desc: Update flake dependencies
     cmds:
-      - nix flake update
+      - bash script/entry_point/update.sh
 
   validate:
     desc: Run comprehensive validation (build + check)
-    deps:
-      - build
-      - check
+    cmds:
+      - bash script/entry_point/build.sh
+      - bash script/entry_point/check.sh
 
   format:
     desc: Format Nix Settings
     cmds:
-      - nix fmt
+      - bash script/entry_point/format.sh
 
   lint:naming:
     desc: Validate file and directory naming conventions with ls-lint
     cmds:
-      - nix run nixpkgs#ls-lint
+      - bash script/entry_point/lint_naming.sh
 
   gc:
     desc: Garbage collect old Nix store paths (keep last 30 days)
     cmds:
-      - nix-collect-garbage --delete-older-than 30d
+      - bash script/entry_point/gc.sh

--- a/nix-darwin/script/entry_point/apply.sh
+++ b/nix-darwin/script/entry_point/apply.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Switch with sudo via the prebuilt darwin-rebuild produced by build.sh, so root
+# only activates the closure and never re-evaluates the flake. Run build.sh first.
+sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin

--- a/nix-darwin/script/entry_point/apply.sh
+++ b/nix-darwin/script/entry_point/apply.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Switch with sudo via the prebuilt darwin-rebuild produced by build.sh, so root
-# only activates the closure and never re-evaluates the flake. Run build.sh first.
+# Switch via the prebuilt darwin-rebuild (build.sh) so root never re-evaluates under sudo.
 sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin

--- a/nix-darwin/script/entry_point/build.sh
+++ b/nix-darwin/script/entry_point/build.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build the system closure as the current user. ./result contains the prebuilt
-# darwin-rebuild, which apply.sh reuses to switch under sudo without re-evaluating
-# the flake (running Nix under sudo loses user config/auth and root-owns the cache).
 nix run github:LnL7/nix-darwin -- build --flake .#shunsock-darwin

--- a/nix-darwin/script/entry_point/build.sh
+++ b/nix-darwin/script/entry_point/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the system closure as the current user. ./result contains the prebuilt
+# darwin-rebuild, which apply.sh reuses to switch under sudo without re-evaluating
+# the flake (running Nix under sudo loses user config/auth and root-owns the cache).
+nix run github:LnL7/nix-darwin -- build --flake .#shunsock-darwin

--- a/nix-darwin/script/entry_point/check.sh
+++ b/nix-darwin/script/entry_point/check.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+nix flake check

--- a/nix-darwin/script/entry_point/format.sh
+++ b/nix-darwin/script/entry_point/format.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+nix fmt

--- a/nix-darwin/script/entry_point/gc.sh
+++ b/nix-darwin/script/entry_point/gc.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Keep the last 30 days of nix store paths.
 nix-collect-garbage --delete-older-than 30d

--- a/nix-darwin/script/entry_point/gc.sh
+++ b/nix-darwin/script/entry_point/gc.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep the last 30 days of nix store paths.
+nix-collect-garbage --delete-older-than 30d

--- a/nix-darwin/script/entry_point/init.sh
+++ b/nix-darwin/script/entry_point/init.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# First-time bootstrap: experimental features may not be enabled in nix.conf yet,
+# so pass them explicitly. Build as the current user, then switch with sudo via the
+# prebuilt binary so root never re-evaluates the flake.
+nix run --extra-experimental-features "nix-command flakes" github:LnL7/nix-darwin -- build --flake .#shunsock-darwin
+sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin
+echo "nix-darwin has been installed system-wide. darwin-rebuild command is now available."

--- a/nix-darwin/script/entry_point/init.sh
+++ b/nix-darwin/script/entry_point/init.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# First-time bootstrap: experimental features may not be enabled in nix.conf yet,
-# so pass them explicitly. Build as the current user, then switch with sudo via the
-# prebuilt binary so root never re-evaluates the flake.
+# Bootstrap: nix.conf may not enable flakes yet, so pass the features explicitly.
 nix run --extra-experimental-features "nix-command flakes" github:LnL7/nix-darwin -- build --flake .#shunsock-darwin
 sudo ./result/sw/bin/darwin-rebuild switch --flake .#shunsock-darwin
 echo "nix-darwin has been installed system-wide. darwin-rebuild command is now available."

--- a/nix-darwin/script/entry_point/lint_naming.sh
+++ b/nix-darwin/script/entry_point/lint_naming.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+nix run nixpkgs#ls-lint

--- a/nix-darwin/script/entry_point/update.sh
+++ b/nix-darwin/script/entry_point/update.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+nix flake update


### PR DESCRIPTION
## 背景

nix-darwin の Taskfile が `darwin-rebuild`（ホストに事前インストールされている前提）に依存していた。これを `nix run` 化し、ホスト環境に rebuild バイナリが無くても apply/init が動作するようにする。

## なぜ apply を2段階に分けたか

`sudo nix run -- switch` のように sudo 下で Nix を動かすと、本来 root 不要な「評価・ビルド」まで root で実行してしまい、以下の問題を踏む:

- ユーザーの `nix.conf`（`experimental-features` 等）が読まれない
- registry / flake input の解決がユーザーコンテキストと異なる
- ビルドキャッシュ (`~/.cache/nix`) が root 所有になる
- private input 取得時に gh/git/SSH agent の認証情報が失われる

root が本当に必要なのは「適用 (switch)」のみ。そこで:

1. ユーザー権限で `build` → `./result` を生成
2. `sudo ./result/sw/bin/darwin-rebuild switch` で**ビルド済みバイナリ**を使って適用（root は再評価しない）

という2段階に分けた。

## 変更内容

### Taskfile (nix-darwin)
- `apply` / `init`: `nix run github:LnL7/nix-darwin -- build` → `sudo ./result/sw/bin/darwin-rebuild switch`

### ドキュメント
- `nix-darwin/README.md` / `nix-darwin/CLAUDE.md` / ルート `CLAUDE.md` の nix-darwin 直接コマンドを同じ2段階パターンに統一

## スコープ
- 今回の変更は **nix-darwin のみ**（nix-os / nvimc は対象外）

## 維持したもの（理由付き）
- **init の Homebrew (`curl`)**: cask 導入のための一回限りブートストラップ。nix-darwin の homebrew 連携は Homebrew 本体の事前インストールを前提とするため
- **`bash` 呼び出し**: POSIX ベースラインで全環境にあるため

## 検証
- `task --list` でパース確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)