### PR TITLE
feat(nix-darwin): flakes/nix-command を宣言的に恒久有効化

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -62,6 +62,14 @@
             nixpkgs.config.allowUnfree = true;
             ids.gids.nixbld = 350;
 
+            # flake / nix-command を恒久的に有効化し、apply 後に
+            # --extra-experimental-features フラグなしで nix コマンドを使えるようにする。
+            # (init 時のブートストラップは Taskfile の inline フラグが担う)
+            nix.settings.experimental-features = [
+              "nix-command"
+              "flakes"
+            ];
+
             # macOS system defaults
             system.defaults.NSGlobalDomain._HIHideMenuBar = true;
           }


### PR DESCRIPTION
## 背景

`task init` のブートストラップは `--extra-experimental-features nix-command flakes` の inline フラグで動くが、init 後に flakes/nix-command を**恒久的に有効化する宣言が flake になく**、インストーラ任せになっていた。そのため `nix flake check` 等が環境依存で落ちうる。

当初は「config に nix.conf を持っておき init 時に `$HOME/.config/nix/` へ copy する」案も検討したが、

- Nix 管理外の状態を生み、apply で追従されずドリフトする（宣言的・再現可能性の原則に反する）
- ブートストラップ用途は既存の Taskfile inline フラグで解決済み

という理由で、**copy ではなく flake での宣言**に倒した。

## 変更

`flake.nix` の system 設定ブロックに以下を追加：

```nix
nix.settings.experimental-features = [ "nix-command" "flakes" ];
```

nix-darwin が `/etc/nix/nix.conf` を生成するため、apply 後はフラグなしで `nix` コマンドが使える。

## 補足

- `allowUnfree` は既に有効化済み（`flake.nix` の `nixpkgs.config.allowUnfree` 他）のため変更なし。
- 恒久設定が効くのは `task apply` を1回流した後。初回 init 直後の反映は darwin-rebuild activation 時。

## 検証

```
$ nix eval .#darwinConfigurations.shunsock-darwin.config.nix.settings.experimental-features
[ "nix-command" "flakes" ]
```

`nix.enable`（デフォルト true）と競合なく解決されることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)