### PR TITLE
fix(nix-darwin): pass --force-cleanup to brew bundle on activation

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -92,6 +92,10 @@
                 # インストール済みパッケージは固定して再現性を優先する。
                 autoUpdate = true;
                 upgrade = false;
+                # Homebrew 5.1 以降、破壊的な `brew bundle --cleanup` は
+                # --force-cleanup / --force / $HOMEBREW_ASK のいずれかを要求する。
+                # nix-darwin は --force 系を生成しないため、cleanup を明示承認する。
+                extraFlags = [ "--force-cleanup" ];
               };
               taps = [
                 "steipete/tap"


### PR DESCRIPTION
## 背景

`task apply` が次のエラーで失敗するようになった。

```
Error: Invalid usage: `brew bundle install --cleanup` requires `--force`, `--force-cleanup` or `$HOMEBREW_ASK`.
```

### 原因の連鎖

1. `flake.nix` の `onActivation.cleanup = "zap"` により、activation で `brew bundle ... --cleanup --zap`（Brewfile にないパッケージを関連ファイルごと削除する破壊的操作）が生成される。
2. `onActivation.autoUpdate = true` により、apply のたびに Homebrew 本体が自動更新され、今回 **Homebrew 5.1.15** に上がった。
3. 新しい Homebrew は破壊的な `brew bundle install --cleanup` に対し、`--force-cleanup` / `--force` / `$HOMEBREW_ASK` のいずれかでの明示承認を要求するガードを追加した。
4. nix-darwin は `cleanup = "zap"` でも `--force` 系を生成しない（upstream 最新版でも同様。`nix flake update` では直らない）。

## 対応

`onActivation.extraFlags = [ "--force-cleanup" ]` を追加し、cleanup（削除）のみを最小権限で明示承認する。`--force` より影響範囲が狭い。「brew は完全に Nix で一元管理」という既存方針（`cleanup = "zap"`）を維持したまま新仕様へ追従する。

## 検証

`nix run github:LnL7/nix-darwin -- build --flake .#shunsock-darwin` 後、生成された activation スクリプトを確認:

```
brew bundle --file='...Brewfile' --no-upgrade --cleanup --zap --force-cleanup
```

`--force-cleanup` が付与され、Homebrew のガードを通過する形になっている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)