### PR TITLE
chore(nix-darwin): 未使用パッケージを削除

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -93,18 +93,13 @@
                 autoUpdate = true;
                 upgrade = false;
               };
-              taps = [
-                "steipete/tap"
-              ];
               brews = [
                 "colima"
                 "curl"
-                "steipete/tap/gogcli"
               ];
               casks = [
                 "aquaskk"
                 "arc"
-                "docker-desktop"
                 "jetbrains-toolbox"
                 "sf-symbols"
                 "steam"

--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -39,23 +39,16 @@
       gh
       ghq
       git
-      gitleaks
       go-task
       hackgen-nf-font
-      hadolint
       hurl
       hyperfine
       nerd-fonts.jetbrains-mono
       nixfmt-rfc-style
-      npins
-      presenterm
       rustup
       tree
-      trufflehog
-      typos
       wthrr
       yazi
-      zoxide
     ]
     ++ [
       complexity


### PR DESCRIPTION
## 概要

nix-darwin で利用していないパッケージを削除しました。

## 削除内容

### `home.nix` (home.packages)
- `gitleaks`
- `hadolint`
- `npins`
- `presenterm`
- `trufflehog`
- `typos`
- `zoxide`

### `flake.nix` (homebrew)
- brews: `gogcli` および専用の tap `steipete/tap`
- casks: `docker-desktop` — コンテナ実行は `colima` に一本化済みのため不要

## 検証

- `nix flake check` → all checks passed
- `nixfmt` でフォーマット済み

`onActivation.cleanup = "zap"` を採用しているため、apply 時に削除済みパッケージは自動でアンインストールされます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)