### PR TITLE
fix(nix-darwin): docker CLI / compose を brews に追加

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -99,6 +99,11 @@
               };
               brews = [
                 "colima"
+                # colima はデーモン (VM) を提供するのみ。docker CLI クライアントと
+                # compose プラグインは Docker Desktop が同梱していたが zap で削除されたため
+                # 明示的に Nix 管理下へ追加する。
+                "docker"
+                "docker-compose"
                 "curl"
               ];
               casks = [

--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -99,9 +99,6 @@
               };
               brews = [
                 "colima"
-                # colima はデーモン (VM) を提供するのみ。docker CLI クライアントと
-                # compose プラグインは Docker Desktop が同梱していたが zap で削除されたため
-                # 明示的に Nix 管理下へ追加する。
                 "docker"
                 "docker-compose"
                 "curl"

--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -57,4 +57,12 @@
       pkgsUnstable.gws
       pkgsLlmAgents.antigravity-cli
     ];
+
+  # docker compose (v2 サブコマンド) の CLI プラグイン登録。
+  # Homebrew の docker-compose は単体バイナリを置くのみで `docker compose` から
+  # 認識されないため、~/.docker/cli-plugins/ に brew の opt パスを symlink する。
+  # 手動で張ると Docker Desktop 削除時の zap で ~/.docker ごと消えるため、
+  # home-manager 管理にして再現性を担保する (opt パスはバージョン非依存)。
+  home.file.".docker/cli-plugins/docker-compose".source =
+    config.lib.file.mkOutOfStoreSymlink "/opt/homebrew/opt/docker-compose/bin/docker-compose";
 }


### PR DESCRIPTION
## 背景

`task apply` 実行時、`homebrew.onActivation.cleanup = "zap"` の挙動により Brewfile に存在しない `docker-desktop` cask が自動アンインストールされた。これにより:

- `==> Removing App '/Applications/Docker.app'`（Docker Desktop 削除）
- `docker` コマンドが `command not found` に
- `docker run ...` を実体とする `v` エイリアス (`nix-darwin/config/bash/alias/vim.bash`) が起動不能に
- さらに zap が `~/.docker` ごと削除し、colima の docker context と compose プラグインも消失

## 原因

`colima` は Lima VM 内で **Docker デーモン** を動かすだけで、**`docker` CLI クライアント** や **compose プラグイン** は同梱しない。これまではそれらを Docker Desktop が提供していたため、cask 削除で CLI 側だけが欠落した。

## 変更

### 1. docker / docker-compose を brews に追加 (`flake.nix`)

- `docker` — docker CLI クライアント (colima デーモンへ接続)
- `docker-compose` — compose 本体

### 2. compose プラグインを home-manager 管理に (`home.nix`)

Homebrew の `docker-compose` は単体バイナリを置くのみで `docker compose` (v2 サブコマンド) から認識されない。`~/.docker/cli-plugins/docker-compose` への symlink が必要だが、手動だと再び zap で消える。

`home.file` + `mkOutOfStoreSymlink` で brew の opt パス (バージョン非依存) をリンクし、再現性を担保した。

## 検証

- `task validate` (build + flake check): ✅ all checks passed
- `nixfmt --check`: ✅ exit 0
- 適用後の実機確認:
  - `docker ps` → ✅ 接続成功 (context `colima *`)
  - `docker compose version` → ✅ `Docker Compose version 5.1.4`

## 適用後の注意

`~/.docker` を削除された環境では、CLI 導入後に一度 `colima restart` を実行して docker context (`colima`) を再生成する必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)