### PR TITLE
refactor(nix-darwin): ユーザー固有の定数を flake.nix の let に集約

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -23,6 +23,12 @@
     }:
     let
       system = "aarch64-darwin";
+
+      # ユーザー固有の値は単一の定義に集約し、flake.nix と home.nix で共有する。
+      # home.nix はモジュールとして import されるため let スコープを共有できない。
+      # extraSpecialArgs 経由で注入する (pkgsUnstable / complexity と同じ機構)。
+      username = "shunsock";
+      homeDirectory = "/Users/${username}";
       pkgs = import nixpkgs {
         inherit system;
         config = {
@@ -52,13 +58,13 @@
     {
       formatter.${system} = pkgs.nixfmt-rfc-style;
 
-      darwinConfigurations."shunsock-darwin" = nix-darwin.lib.darwinSystem {
+      darwinConfigurations."${username}-darwin" = nix-darwin.lib.darwinSystem {
         inherit system;
         modules = [
           # System configuration
           {
             system.stateVersion = 4;
-            system.primaryUser = "shunsock";
+            system.primaryUser = username;
             nixpkgs.config.allowUnfree = true;
             ids.gids.nixbld = 350;
 
@@ -123,9 +129,11 @@
                 inherit pkgsUnstable;
                 inherit pkgsLlmAgents;
                 inherit complexity;
+                inherit username;
+                inherit homeDirectory;
               };
 
-              users.shunsock = import ./home.nix;
+              users.${username} = import ./home.nix;
 
               backupFileExtension = "hm-backup";
             };

--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -4,6 +4,8 @@
   pkgsUnstable,
   pkgsLlmAgents,
   complexity,
+  username,
+  homeDirectory,
   lib,
   ...
 }:
@@ -20,8 +22,8 @@
   ];
 
   # ユーザー情報
-  home.username = "shunsock";
-  home.homeDirectory = lib.mkForce "/Users/shunsock";
+  home.username = username;
+  home.homeDirectory = lib.mkForce homeDirectory;
   home.stateVersion = "23.11";
 
   # フォント設定


### PR DESCRIPTION
## 背景

`nix-darwin/flake.nix` と `home.nix` を眺めていて、ユーザー名 `"shunsock"` が複数箇所にハードコードされていることに気づいた。flake.nix に 3 箇所 (`darwinConfigurations` 名 / `system.primaryUser` / `users.<name>`)、home.nix に 1 箇所 (`home.username`)、さらにホームディレクトリ `/Users/shunsock` も別の文字列リテラルとして home.nix に存在していた。

同じ値が散らばっていると、ユーザー名を変えたいときに修正漏れのリスクがある。これを単一の定義に集約できないかを検討した。

## 設計判断

### なぜ extraSpecialArgs 経由なのか

`home.nix` は `users.<name> = import ./home.nix;` で **モジュールとして import** されるため、flake.nix の `let in` スコープを共有できない。単純に let 変数を参照させることはできない。

このリポジトリには既に `pkgsUnstable` / `complexity` を `extraSpecialArgs` で注入する確立済みのパターンがある。`username` / `homeDirectory` も同じ機構に揃えることで、「設定値は外部から注入する」という既存の設計方針 (依存性逆転) に沿った形にした。

### homeDirectory は username から導出

`homeDirectory = "/Users/${username}"` とし、ユーザー名さえ変えれば連動するようにした。これで変更点が flake.nix の let の 1 行に局所化される。

### 共通化を見送ったもの

- **nixpkgs `25.11` (inputs に 3 箇所)**: `inputs` ブロックは `let in` より先に評価されるため、Nix の言語仕様上 let 変数を参照できない。定数化不可。
- **stateVersion**: `system.stateVersion = 4` (整数) と `home.stateVersion = "23.11"` (文字列) は意味も型も別物のため対象外。

## 変更点

- `flake.nix`: let に `username` / `homeDirectory` を追加し、`darwinConfigurations."${username}-darwin"` / `system.primaryUser` / `users.${username}` で参照。`extraSpecialArgs` に両者を追加。
- `home.nix`: 関数引数に `username` / `homeDirectory` を追加し、`home.username` / `home.homeDirectory` で参照。

## 検証

- `task validate` (build + check) 成功。`darwinConfigurations."${username}-darwin"` は `shunsock-darwin` に解決され、ビルドスクリプトのターゲットと一致することを確認済み。
- 編集ファイルは `nixfmt` で整形済み (差分なし)。

> [!NOTE]
> 反映には `task apply` (sudo) が必要なため、マージ後にローカルで実行が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)