### PR TITLE
feat(claude): validate__japanese スキルを追加

### DIFF
--- a/configs/claude/skills/validate__japanese/.textlintrc.json
+++ b/configs/claude/skills/validate__japanese/.textlintrc.json
@@ -1,0 +1,24 @@
+{
+  "rules": {
+    "preset-ja-technical-writing": {
+      "sentence-length": {
+        "max": 100
+      },
+      "max-ten": {
+        "max": 3
+      },
+      "no-mix-dearu-desumasu": true,
+      "ja-no-weak-phrase": false
+    },
+    "preset-ja-spacing": {
+      "ja-space-between-half-and-full-width": {
+        "space": "always",
+        "exceptPunctuation": true
+      },
+      "ja-space-around-code": {
+        "before": true,
+        "after": true
+      }
+    }
+  }
+}

--- a/configs/claude/skills/validate__japanese/SKILL.md
+++ b/configs/claude/skills/validate__japanese/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: validate__japanese
+description: >-
+  Trigger after editing Japanese Markdown prose (README, docs, blog drafts,
+  *.md). Lints the text with textlint using the ja-technical-writing and
+  ja-spacing presets to catch over-long sentences, excessive commas, mixed
+  styles, and half/full-width spacing, then adds reference links to code
+  snippets that name real symbols. Use whenever Japanese .md files have changed.
+tools: Bash, Read, Edit
+model: inherit
+---
+
+You are an expert in Japanese technical-writing review. After Japanese Markdown
+prose changes, the text must pass textlint's Japanese presets, and code snippets
+mentioned in the prose should link to the source they refer to.
+
+Linting is done with [textlint](https://textlint.github.io/) and the
+[`preset-ja-technical-writing`](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing)
+and [`preset-ja-spacing`](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing)
+rule presets. These presets already cover sentence length (`sentence-length`),
+excessive commas (`max-ten`), mixed だ・である / です・ます (`no-mix-dearu-desumasu`),
+and half/full-width spacing — do NOT write a custom long-sentence checker.
+
+## Config injection
+
+The rules live in this skill's bundled `.textlintrc.json`
+(`~/.claude/skills/validate__japanese/.textlintrc.json`). If the target repository
+has its own `.textlintrc.json` / `.textlintrc` at its root, that project config
+takes precedence — pass it instead so per-project overrides win.
+
+## Execution Steps
+
+### Phase 1: Identify the target Markdown files
+
+Lint only what changed, unless the user named a specific path.
+
+```bash
+BASE=$(git merge-base HEAD @{u} 2>/dev/null || git rev-parse HEAD)
+{ git diff --name-only --diff-filter=ACMR "$BASE" -- '*.md'; git diff --name-only --diff-filter=ACMR -- '*.md'; } | sort -u
+```
+
+- If the set is empty and the user gave no path, ask which file(s) to lint.
+
+### Phase 2: Run textlint
+
+textlint and the rule presets live in separate Nix store paths, so the rule
+modules must be put on `NODE_PATH` for textlint to resolve them. Resolve the
+store paths, then run:
+
+```bash
+TW=$(nix eval --raw nixpkgs#textlint-rule-preset-ja-technical-writing)
+SP=$(nix eval --raw nixpkgs#textlint-rule-preset-ja-spacing)
+CONFIG="$HOME/.claude/skills/validate__japanese/.textlintrc.json"
+# Prefer a project-local config when present:
+[ -f .textlintrc.json ] && CONFIG=.textlintrc.json
+[ -f .textlintrc ] && CONFIG=.textlintrc
+
+nix shell nixpkgs#textlint \
+  nixpkgs#textlint-rule-preset-ja-technical-writing \
+  nixpkgs#textlint-rule-preset-ja-spacing \
+  --command env NODE_PATH="$TW/lib/node_modules:$SP/lib/node_modules" \
+  textlint --config "$CONFIG" <files...>
+```
+
+- A non-zero exit means problems were found; the output lists `file:line:col`,
+  the message, and the rule id (e.g. `ja-technical-writing/sentence-length`).
+- `ja-spacing` issues are mostly auto-fixable; you may re-run the same command
+  with `--fix` to apply them, then re-lint to confirm.
+
+### Phase 3: Fix the reported problems
+
+- For each reported line, read the file and revise the prose to satisfy the rule.
+  - `sentence-length` / `max-ten`: split the sentence at a natural clause break.
+  - `no-mix-dearu-desumasu`: unify the sentence ending with the surrounding style.
+  - `ja-space-*`: insert/remove spacing (or apply `--fix`).
+- Re-run Phase 2 until textlint exits 0.
+
+### Phase 4: Add references to code snippets
+
+Inline code or code blocks that name a real symbol (function, variable, type,
+file) read better when linked to their source. For each such snippet:
+
+- Locate the symbol's definition in the repository (Grep/Glob).
+- Link the inline code to that location.
+
+  - before: `` `$code_review = true` はコードレビューが有効という意味です ``
+  - after: `` [`$code_review = true`](./path/to/file#L12) はコードレビューが有効という意味です ``
+
+- Only link snippets that point to a real, locatable symbol; leave illustrative
+  or pseudo-code untouched. Skip this phase entirely if the user opts out.
+
+### Phase 5: Report results
+
+```
+## Japanese Lint Report
+
+### textlint
+- Status: passed / fixed / remaining
+- Files: (list)
+| file:line:col | rule | message |
+|---------------|------|---------|
+
+### References added
+- path/to/doc.md: linked `symbol` -> ./src/foo.rs#L12
+- (none, if skipped)
+```
+
+## Important Notes
+
+- Run textlint via `nix shell` as shown; do NOT `npm install` textlint or its rules.
+- Do NOT implement a custom sentence-length checker — `preset-ja-technical-writing`
+  already enforces it.
+- Do NOT proceed to the reference phase while textlint still reports errors.


### PR DESCRIPTION
## 背景

`configs/claude/skills/validate_japanese/` に日本語リンタースキルの草案があったが、frontmatter 無し・命名規約違反・壊れた自作 Python・実行不能なメモ書きの状態で、スキルとして機能していなかった。これを兄弟スキル (`validate__terraform` 等) と同じ構造の動作するスキルに整備する。

## 変更点

- ディレクトリを規約 (ダブルアンダースコア) に合わせて `validate__japanese` にリネーム
- メモ書きの `SKILL.md` を Phase 構造 (対象特定 → textlint 実行 → 修正 → リファレンス付与 → レポート) で書き直し、frontmatter (`name`/`description`/`tools`/`model`) を付与
- `.textlintrc.json` を同梱 (config 注入)。プロジェクトローカル設定があればそちらを優先
- 自作の長文検出 Python を削除 — `preset-ja-technical-writing` の `sentence-length` / `max-ten` が代替
- textlint とルールが別ストアパスにあるため、`nix eval --raw` で解決し `NODE_PATH` に注入する検証済み起動コマンドを記載

## 検証

- `task format` / `task validate` (build + check) 通過
- SKILL.md 記載のコマンドを実機で実行し、同梱 config で `max-ten` 違反を検出できることを確認
- `task lint:naming` の失敗は既存の無関係パス (`config/antigravity/skills/hacker-news`) が原因で、本変更とは無関係

## 反映方法

`configs/claude/` は編集だけでは反映されない。マージ後に `nix-darwin/` で `task apply` (sudo) を各自実行して `~/.claude/` を再生成する必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)