### PR TITLE
chore: 未使用の samoyed pre-commit hook を撤去

### DIFF
--- a/.samoyed/pre-commit
+++ b/.samoyed/pre-commit
@@ -1,8 +1,0 @@
-#!/usr/bin/env sh
-# Block staged secrets at commit time. Bypass: SAMOYED=0 git commit ...
-set -eu
-if ! command -v gitleaks >/dev/null 2>&1; then
-  echo "gitleaks not found in PATH; run 'darwin-rebuild switch' or 'nixos-rebuild switch' first." >&2
-  exit 1
-fi
-exec gitleaks protect --staged --redact --verbose

--- a/nix-os/flake.lock
+++ b/nix-os/flake.lock
@@ -80,24 +80,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -205,22 +187,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "noctalia": {
       "inputs": {
         "nixpkgs": [
@@ -247,66 +213,10 @@
         "llm-agents": "llm-agents",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "noctalia": "noctalia",
-        "samoyed": "samoyed"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1758422215,
-        "narHash": "sha256-JvF5SXhp1wBHbfEVAWgJCDVSO8iknfDqXfqMch5YWg0=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "6f3988eb5885f1e2efa874a480d91de09a7f9f0b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "samoyed": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-overlay": "rust-overlay"
-      },
-      "locked": {
-        "lastModified": 1774535927,
-        "narHash": "sha256-yIUSQryRWRo65LWc+yzDwhj//K0EDxhim8tBmwV7WY0=",
-        "owner": "espiria",
-        "repo": "samoyed",
-        "rev": "93939e4092fdd7a8097eb91037e956f0c435264b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "espiria",
-        "repo": "samoyed",
-        "type": "github"
+        "noctalia": "noctalia"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/nix-os/flake.nix
+++ b/nix-os/flake.nix
@@ -11,10 +11,6 @@
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
     llm-agents.url = "github:numtide/llm-agents.nix";
-    samoyed = {
-      url = "github:espiria/samoyed";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
@@ -25,7 +21,6 @@
       home-manager,
       noctalia,
       llm-agents,
-      samoyed,
       ...
     }:
     let
@@ -43,7 +38,6 @@
         };
       };
       pkgsLlmAgents = llm-agents.packages.${system};
-      samoyedPkg = samoyed.packages.${system}.default;
 
       # thoughtbot/complexity: cognitive complexity measurement tool
       complexity = pkgs.rustPlatform.buildRustPackage rec {
@@ -79,7 +73,6 @@
                   inherit pkgsUnstable;
                   inherit pkgsLlmAgents;
                   inherit complexity;
-                  inherit samoyedPkg;
                 };
 
                 users.shunsock = import ./home.nix;

--- a/nix-os/home.nix
+++ b/nix-os/home.nix
@@ -4,7 +4,6 @@
   pkgsUnstable,
   pkgsLlmAgents,
   complexity,
-  samoyedPkg,
   lib,
   ...
 }:
@@ -45,6 +44,5 @@
     ++ [
       complexity
       pkgsLlmAgents.claude-code
-      samoyedPkg
     ];
 }


### PR DESCRIPTION
## 背景

`.samoyed/pre-commit` (gitleaks を実行する samoyed の pre-commit フック) を使っていないため削除する。フックが無くなると samoyed (gitleaks ラッパー) を導入する意味が無くなるので、nix-os 側の配線も合わせて撤去し、宙に浮いたインストールを残さない。

## 変更点

- `.samoyed/pre-commit` を削除
- `nix-os/flake.nix`: `samoyed` flake input / outputs 引数 / `samoyedPkg` 定義 / `inherit samoyedPkg` を除去
- `nix-os/home.nix`: `samoyedPkg` 引数と `home.packages` への追加を除去
- `nix-os/flake.lock`: `samoyed` 関連のロックエントリを `nix flake lock` で除去

シークレット検出は `home.packages` に残る `gitleaks` / `trufflehog` で引き続き手動実行できる。

## 検証

- `nix eval .#nixosConfigurations.myNixOS.config.system.build.toplevel.drvPath` で構成全体が評価成功 (`samoyedPkg` 参照の取り残し・構文エラーが無いことを確認)
- nixfmt-rfc-style で追加フォーマット変更なし
- ※ nix-os は Linux 構成のため darwin 環境では toplevel のビルド検証は不可。マージ後に NixOS 環境で `task validate` を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)