### PR TITLE
feat(claude): 日本語テクニカルライティング lint を強化し task lint:natural_language を追加

### DIFF
--- a/configs/claude/skills/validate__japanese/.textlintrc.json
+++ b/configs/claude/skills/validate__japanese/.textlintrc.json
@@ -2,13 +2,27 @@
   "rules": {
     "preset-ja-technical-writing": {
       "sentence-length": {
-        "max": 100
+        "max": 50
+      },
+      "max-comma": {
+        "max": 4
       },
       "max-ten": {
         "max": 3
       },
-      "no-mix-dearu-desumasu": true,
-      "ja-no-weak-phrase": false
+      "max-kanji-continuous-len": {
+        "max": 6
+      },
+      "no-mix-dearu-desumasu": {
+        "strict": true
+      },
+      "ja-no-weak-phrase": true,
+      "ja-no-redundant-expression": true,
+      "ja-no-abusage": true,
+      "no-double-negative-ja": true,
+      "no-doubled-joshi": {
+        "min_interval": 1
+      }
     },
     "preset-ja-spacing": {
       "ja-space-between-half-and-full-width": {

--- a/configs/claude/skills/validate__japanese/SKILL.md
+++ b/configs/claude/skills/validate__japanese/SKILL.md
@@ -21,6 +21,11 @@ rule presets. These presets already cover sentence length (`sentence-length`),
 excessive commas (`max-ten`), mixed だ・である / です・ます (`no-mix-dearu-desumasu`),
 and half/full-width spacing — do NOT write a custom long-sentence checker.
 
+The bundled config is tuned for strict technical writing: sentences are capped at
+50 characters, weak phrasing (`ja-no-weak-phrase`) and redundant expressions
+(`ja-no-redundant-expression`) are flagged. Most of these are report-only; only
+spacing issues are auto-fixable with `--fix`.
+
 ## Config injection
 
 The rules live in this skill's bundled `.textlintrc.json`

--- a/nix-darwin/Taskfile.yml
+++ b/nix-darwin/Taskfile.yml
@@ -52,6 +52,11 @@ tasks:
     cmds:
       - bash script/entry_point/shellcheck/lint.sh
 
+  lint:natural_language:
+    desc: Proofread and auto-fix Japanese prose in configs/claude with textlint
+    cmds:
+      - bash script/entry_point/textlint/lint.sh
+
   gc:
     desc: Garbage collect old Nix store paths (keep last 30 days)
     cmds:

--- a/nix-darwin/script/entry_point/textlint/lint.sh
+++ b/nix-darwin/script/entry_point/textlint/lint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$SCRIPT_ROOT/library/runner.sh"
+
+# 校正対象はリポジトリの Claude 設定 (configs/claude) 配下の Markdown。
+# SCRIPT_ROOT は nix-darwin/script なので、2 つ上がリポジトリルート。
+REPO_ROOT="$(cd "$SCRIPT_ROOT/../.." && pwd)"
+TARGET_DIR="$REPO_ROOT/configs/claude"
+# ルールは validate__japanese スキルの設定を single source として共有する。
+CONFIG="$REPO_ROOT/configs/claude/skills/validate__japanese/.textlintrc.json"
+
+# textlint 本体と ja ルールプリセットは別々の Nix ストアパスに入るため、
+# textlint がルールを解決できるよう各プリセットの node_modules を NODE_PATH に通す。
+technical_writing="$(nix eval --raw nixpkgs#textlint-rule-preset-ja-technical-writing)"
+spacing="$(nix eval --raw nixpkgs#textlint-rule-preset-ja-spacing)"
+node_path="$technical_writing/lib/node_modules:$spacing/lib/node_modules"
+
+# 対象 Markdown を収集する。
+# mapfile は macOS 標準の bash 3.2 に無いため while-read で配列に積む。
+md_files=()
+while IFS= read -r file; do
+  md_files+=("$file")
+done < <(find "$TARGET_DIR" -name '*.md')
+
+# textlint の起動をまとめる。第1引数以降がそのまま textlint の引数になる。
+textlint() {
+  nix shell nixpkgs#textlint \
+    nixpkgs#textlint-rule-preset-ja-technical-writing \
+    nixpkgs#textlint-rule-preset-ja-spacing \
+    --command env NODE_PATH="$node_path" \
+    textlint --config "$CONFIG" "$@"
+}
+
+# Phase 1: 自動修正の適用。
+# textlint --fix は「修正不能な指摘 (一文の長さ等)」を出力にも終了コードにも反映せず
+# exit 0 で終わる。そのためこのパスでは合否を判定せず、修正適用だけを目的にする。
+info "自動修正可能な指摘 (全角・半角間スペース等) を適用します"
+textlint --fix "${md_files[@]}" || true
+
+# Phase 2: 再検査と報告。
+# 自動修正後に残る指摘 (一文の長さ・助詞の重複など手動対応が必要なもの) を出力し、
+# その有無で run の終了コード = タスクの合否を決める。
+run "日本語テクニカルライティングの校正" \
+  textlint "${md_files[@]}"


### PR DESCRIPTION
## 背景

`validate__japanese` スキルの textlint 設定を技術文書向けに厳格化し、ローカルから `task lint:natural_language` で `configs/claude` 配下の日本語 Markdown を校正・自動修正できるようにする。

ルールは nixpkgs にある範囲 (`preset-ja-technical-writing` / `preset-ja-spacing`) で固める。JTF スタイルガイドやひらがな化・助詞重複などの主要拡張は nixpkgs 未提供かつ npm 禁止の制約上導入できないため、既存プリセットの厳格化で対応する。

## 変更点

### 設定の厳格化 (`.textlintrc.json`)
- `sentence-length` の上限を **50 文字** に設定
- `ja-no-weak-phrase` を有効化 (従来は無効)
- `ja-no-redundant-expression` / `ja-no-abusage` / `no-double-negative-ja` / `max-comma` / `max-kanji-continuous-len` を明示的に有効化
- `no-mix-dearu-desumasu` を `strict: true` に

### task の追加
- `nix-darwin/Taskfile.yml` に `lint:natural_language` を追加
- `script/entry_point/textlint/lint.sh` を新設

### entry script は **2 フェーズ構成**
`textlint --fix` は修正不能な指摘 (一文の長さ・助詞重複など report-only ルール) を**出力にも終了コードにも反映せず exit 0** で終わる。`--fix` 単体ではこれらが利用者に見えずゲートにもならないため、以下に分離した:
1. `--fix` で自動修正可能な指摘 (全角・半角間スペース等) を適用
2. check モードで再検査し、残る指摘を報告して合否 (終了コード) を決める

## 文長 50 文字の根拠

`configs/claude` 28 ファイルに対し閾値ごとの sentence-length 指摘数を実測:

| 上限 | 指摘数 |
|---|---|
| 45 | 434 |
| **50** | 371 |
| 60 | 282 |
| 100 (デフォルト) | 88 |

一般向け技術文書では一文 40〜50 字が読みやすさの定番ライン。50 はその範囲内で現実的なため採用した。

## 検証

- `task lint:shell` (shellcheck): 成功
- `task lint:natural_language`: Phase 1 で 123 件を自動修正 → Phase 2 で残り 443 件 (うち sentence-length 374 件) を報告し非ゼロ終了。意図通りゲートとして機能
- `task validate` (darwin build + check): 成功 (配布される config が壊れていないことを確認)
- 本 PR はツール追加のみ。既存ドキュメントへの一括修正は含めない (`task lint:natural_language` 実行時に適用する想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)