### PR TITLE
feat(claude): validate__japanese に文中ハードラップ検出を追加

### DIFF
--- a/configs/claude/skills/validate__japanese/SKILL.md
+++ b/configs/claude/skills/validate__japanese/SKILL.md
@@ -1,38 +1,20 @@
 ---
 name: validate__japanese
 description: >-
-  日本語の Markdown 文書 (README・ドキュメント・ブログ下書き・*.md) を編集した
-  後に起動する。textlint の ja-technical-writing / ja-spacing プリセットで、
-  長すぎる一文・読点過多・文体の混在・全角半角スペースを検出する。さらに実在の
-  シンボルを指すコードスニペットへ参照リンクを付与する。日本語の .md を変更した
-  ときに使用する。
+  日本語の Markdown 文書 (README・ドキュメント・ブログ下書き・*.md) を編集した後に起動する。textlint の ja-technical-writing / ja-spacing プリセットで、長すぎる一文・読点過多・文体の混在・全角半角スペースを検出する。さらに文中ハードラップ (文末でない位置で折り返した、意味のない改行) を検出し、段落・箇条書き項目を 1 行に連結して調整する。実在のシンボルを指すコードスニペットへ参照リンクも付与する。日本語の .md を変更したときに使用する。
 tools: Bash, Read, Edit
 model: inherit
 ---
 
-あなたは日本語テクニカルライティングのレビューの専門家である。日本語 Markdown を
-変更したら、textlint の日本語プリセットを通す。また、文章中で言及するコード
-スニペットは、その参照元へリンクするとよい。
+あなたは日本語テクニカルライティングのレビューの専門家である。日本語 Markdown を変更したら、textlint の日本語プリセットを通す。さらに、文の途中で折り返した意味のない改行 (文中ハードラップ) を検出し、段落や箇条書き項目を 1 行に連結する。また、文章中で言及するコードスニペットは、その参照元へリンクするとよい。
 
-リントには [textlint](https://textlint.github.io/) と
-[`preset-ja-technical-writing`](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing)・
-[`preset-ja-spacing`](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing)
-プリセットを使う。これらは一文の長さ (`sentence-length`) や読点過多 (`max-ten`) を
-検出する。常体と敬体の混在 (`no-mix-dearu-desumasu`) や全角半角スペースも網羅する。
-長文チェックを自作してはならない。
+リントには [textlint](https://textlint.github.io/) と [`preset-ja-technical-writing`](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing)・[`preset-ja-spacing`](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing) プリセットを使う。これらは一文の長さ (`sentence-length`) や読点過多 (`max-ten`) を検出する。常体と敬体の混在 (`no-mix-dearu-desumasu`) や全角半角スペースも網羅する。長文チェックを自作してはならない。
 
-同梱の設定は技術文書向けに厳格化してある。一文は 50 文字までに制限する。弱い表現
-(`ja-no-weak-phrase`) や冗長表現 (`ja-no-redundant-expression`) も検出する。ただし
-`sentence-length` は 12 文字以上の連続 ASCII (コマンドやパス) を長さから除外する。
-そのため、コマンドを含む箇条書きを過検出しない。多くは報告のみで、自動修正できるのは
-スペース系だけである。
+同梱の設定は技術文書向けに厳格化してある。一文は 50 文字までに制限する。弱い表現 (`ja-no-weak-phrase`) や冗長表現 (`ja-no-redundant-expression`) も検出する。ただし `sentence-length` は 12 文字以上の連続 ASCII (コマンドやパス) を長さから除外する。そのため、コマンドを含む箇条書きを過検出しない。多くは報告のみで、自動修正できるのはスペース系だけである。
 
 ## 設定の注入
 
-ルールはこのスキルが同梱する `.textlintrc.json`
-(`~/.claude/skills/validate__japanese/.textlintrc.json`) に置く。対象リポジトリの
-ルートに独自の `.textlintrc.json` / `.textlintrc` があれば、そちらを優先する。
-プロジェクト固有の上書きを効かせるため、その設定を渡す。
+ルールはこのスキルが同梱する `.textlintrc.json` (`~/.claude/skills/validate__japanese/.textlintrc.json`) に置く。対象リポジトリのルートに独自の `.textlintrc.json` / `.textlintrc` があれば、そちらを優先する。プロジェクト固有の上書きを効かせるため、その設定を渡す。
 
 ## 実行手順
 
@@ -49,8 +31,7 @@ BASE=$(git merge-base HEAD @{u} 2>/dev/null || git rev-parse HEAD)
 
 ### Phase 2: textlint の実行
 
-textlint とルールプリセットは別々の Nix ストアパスに入る。textlint が解決できるよう、
-ルールモジュールを `NODE_PATH` に通す必要がある。ストアパスを解決してから実行する:
+textlint とルールプリセットは別々の Nix ストアパスに入る。textlint が解決できるよう、ルールモジュールを `NODE_PATH` に通す必要がある。ストアパスを解決してから実行する:
 
 ```bash
 TW=$(nix eval --raw nixpkgs#textlint-rule-preset-ja-technical-writing)
@@ -67,10 +48,8 @@ nix shell nixpkgs#textlint \
   textlint --config "$CONFIG" <files...>
 ```
 
-- 非ゼロ終了は問題ありを意味する。出力は `file:line:col`・メッセージ・ルール ID
-  (例 `ja-technical-writing/sentence-length`) を並べる。
-- `ja-spacing` の指摘はほぼ自動修正できる。同じコマンドに `--fix` を付けて再実行し、
-  再リントで確認するとよい。
+- 非ゼロ終了は問題ありを意味する。出力は `file:line:col`・メッセージ・ルール ID (例 `ja-technical-writing/sentence-length`) を並べる。
+- `ja-spacing` の指摘はほぼ自動修正できる。同じコマンドに `--fix` を付けて再実行し、再リントで確認するとよい。
 
 ### Phase 3: 指摘の修正
 
@@ -80,10 +59,40 @@ nix shell nixpkgs#textlint \
   - `ja-space-*`: スペースを挿入・削除する (または `--fix` を適用する)。
 - textlint が 0 件で終わるまで Phase 2 を繰り返す。
 
-### Phase 4: コードスニペットへの参照付与
+### Phase 4: 文中ハードラップの検出と連結
 
-実在のシンボル (関数・変数・型・ファイル) を指すインラインコードやコードブロックがある。
-これらは参照元へリンクすると読みやすい。該当するスニペットごとに次を行う:
+ユーザーは段落・箇条書き項目それぞれを 1 行に流すことを好む。文の途中で折り返したハードラップ改行は意味のない改行であり、連結して調整する。textlint のプリセットにはこの検出ルールが無いため、この手順で扱う。
+
+**意味のない改行の定義 (検出対象):** プローズ段落の中で、行末が文末記号で終わっていないのに、次の行が空行でなく同じ段落の継続である改行を指す。これが文中ハードラップである。文末記号は `。` `！` `？` (全角・半角の両方) を含み、`。」` `。）` のように閉じ括弧を伴う文末も文末として扱う。
+
+**除外 (連結してはならないもの):**
+
+- コードフェンス (` ``` ` で囲まれた範囲) の内側、およびインラインで完結しないコードブロック。
+- 表の行 (`|` 区切り)。
+- 箇条書き・番号付きリストの項目区切り。ただし 1 項目が文中で折り返されている継続行は連結対象に含めてよい。
+- 見出し (`#`)、引用 (`>`)、HTML タグ行、YAML フロントマター。
+- 行末が Markdown の意図的な改行 (行末スペース 2 個、または末尾 `\`) の場合。
+- 迷ったら連結せず、報告にとどめる。
+
+**検出の補助:** 候補行を機械的に絞り込むには次のワンライナーが使える。文末記号でも継続記号でも終わらない非空行を、おおまかな候補として挙げる。
+
+```bash
+# 候補行のおおまかな抽出 (要 Read による最終確認)。
+# 文末記号 (。！？.!?) や閉じ括弧、行末スペース2個、末尾 \ で終わらない非空行を拾う。
+grep -nvE '(^[[:space:]]*$|[。．！？.!?」』）\)]$|[\\]$| {2,}$)' <file>
+```
+
+このワンライナーはあくまで候補を挙げるだけである。日本語の文末判定は難しく、見出し・表・コードフェンス・リスト項目を誤って拾うため、最終判断は必ず Read で各候補行とその次行を確認してから行う。自前の大掛かりなパーサは作らない。
+
+**調整方法:** 文中で割れている行を次の行と連結する。日本語の連結時はスペースを入れない。連結境界の両側がどちらも ASCII の場合のみ半角スペース 1 個を保持する。連結はコードの挙動・文意を変えてはならない。
+
+- Read で対象行と次行の文脈を確認し、上の除外条件に該当しないことを確かめる。
+- Edit で 2 行を 1 行へ連結する。連結後に Phase 2 の textlint を再実行し、新たな指摘が出ないことを確認する。
+- 連結すべきか判断できない行は、連結せず Phase 6 の報告に残す。
+
+### Phase 5: コードスニペットへの参照付与
+
+実在のシンボル (関数・変数・型・ファイル) を指すインラインコードやコードブロックがある。これらは参照元へリンクすると読みやすい。該当するスニペットごとに次を行う:
 
 - リポジトリ内でそのシンボルの定義を探す (Grep/Glob)。
 - インラインコードをその箇所へリンクする。
@@ -91,10 +100,9 @@ nix shell nixpkgs#textlint \
   - before: `` `$code_review = true` はコードレビューが有効という意味です ``
   - after: `` [`$code_review = true`](./path/to/file#L12) はコードレビューが有効という意味です ``
 
-- 実在し位置を特定できるシンボルを指すものだけリンクする。説明用や擬似コードはそのまま
-  にする。ユーザーが望まなければ、このフェーズは丸ごと省略する。
+- 実在し位置を特定できるシンボルを指すものだけリンクする。説明用や擬似コードはそのままにする。ユーザーが望まなければ、このフェーズは丸ごと省略する。
 
-### Phase 5: 結果の報告
+### Phase 6: 結果の報告
 
 ```
 ## 日本語リントレポート
@@ -105,6 +113,10 @@ nix shell nixpkgs#textlint \
 | file:line:col | rule | message |
 |---------------|------|---------|
 
+### 文中ハードラップの調整
+- 連結した箇所: path/to/doc.md:12-13 など (一覧)
+- 連結を見送った箇所と理由: (一覧、無ければ none)
+
 ### 付与した参照
 - path/to/doc.md: `symbol` を ./src/foo.rs#L12 へリンク
 - (省略した場合は none)
@@ -112,7 +124,8 @@ nix shell nixpkgs#textlint \
 
 ## 重要な注意
 
-- textlint は上記のとおり `nix shell` 経由で実行する。textlint やルールを
-  `npm install` してはならない。
+- textlint は上記のとおり `nix shell` 経由で実行する。textlint やルールを `npm install` してはならない。
 - 長文チェックを自作してはならない。`preset-ja-technical-writing` がすでに強制する。
-- textlint がエラーを報告する間は、参照フェーズに進んではならない。
+- 文中ハードラップの検出も大掛かりなパーサを自作しない。grep の候補抽出と Read による確認で判断する。
+- 連結はコードの挙動・文意を変えない範囲に限る。迷ったら連結せず報告する。
+- textlint がエラーを報告する間は、ハードラップ調整や参照フェーズに進んではならない。


### PR DESCRIPTION
## Summary
- `validate__japanese` スキルに、文末でない位置で折り返した意味のない改行 (文中ハードラップ) を検出し、段落・箇条書き項目を 1 行に連結する手順を Phase 4 として追加
- 検出対象 (文末記号で終わらない継続改行)・除外条件 (コードフェンス / 表 / リスト区切り / 見出し / 引用 / HTML / フロントマター / 意図的改行) を定義
- grep による候補抽出ワンライナーを掲載しつつ、最終判断は Read で確認してから Edit する手順に統一
- 連結方法 (日本語はスペース無し、ASCII 同士のみ半角スペース 1 個) を明記
- description に本機能を追記し、後続の参照付与を Phase 5、報告を Phase 6 に振り直し
- 報告フォーマットにハードラップ調整結果の節を追加
- SKILL.md 本文自体も「段落は 1 行に流す」新方針に合わせて書き直し

## Motivation
ユーザーは日本語 Markdown 本文で文中ハードラップを嫌い、各段落・各箇条書き項目を 1 行に流すことを好む。textlint のプリセットにはこの検出ルールが無いため、スキル内の手順 (ヒューリスティック検出 + Read/Edit による連結) として実装した。

## Verification
- [x] nix build: passed (`darwinConfigurations.shunsock-darwin.system`)
- [x] nix flake check: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)