### PR TITLE
fix(claude): フック改称漏れによるビルド失敗を修正

### DIFF
--- a/nix-darwin/module/claude.nix
+++ b/nix-darwin/module/claude.nix
@@ -38,7 +38,7 @@
   home.activation.claudeHooks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     run mkdir -p $HOME/.claude/hooks
     run install -Dm755 ${../../configs/claude/hooks/validate-bash.sh} $HOME/.claude/hooks/validate-bash.sh
-    run install -Dm755 ${../../configs/claude/hooks/enforce-narrative-pr.sh} $HOME/.claude/hooks/enforce-narrative-pr.sh
+    run install -Dm755 ${../../configs/claude/hooks/pr-submission-via-skill.sh} $HOME/.claude/hooks/pr-submission-via-skill.sh
     run install -Dm755 ${../../configs/claude/hooks/trigger-ci-fix.sh} $HOME/.claude/hooks/trigger-ci-fix.sh
     run install -Dm755 ${../../configs/claude/hooks/recommend-tasks.sh} $HOME/.claude/hooks/recommend-tasks.sh
     run install -Dm755 ${../../configs/claude/hooks/clean-comment-out.sh} $HOME/.claude/hooks/clean-comment-out.sh

--- a/nix-os/modules/claude.nix
+++ b/nix-os/modules/claude.nix
@@ -28,7 +28,7 @@
   home.activation.claudeHooks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     run mkdir -p $HOME/.claude/hooks
     run install -Dm755 ${../../configs/claude/hooks/validate-bash.sh} $HOME/.claude/hooks/validate-bash.sh
-    run install -Dm755 ${../../configs/claude/hooks/enforce-narrative-pr.sh} $HOME/.claude/hooks/enforce-narrative-pr.sh
+    run install -Dm755 ${../../configs/claude/hooks/pr-submission-via-skill.sh} $HOME/.claude/hooks/pr-submission-via-skill.sh
     run install -Dm755 ${../../configs/claude/hooks/trigger-ci-fix.sh} $HOME/.claude/hooks/trigger-ci-fix.sh
     run install -Dm755 ${../../configs/claude/hooks/clean-comment-out.sh} $HOME/.claude/hooks/clean-comment-out.sh
   '';


### PR DESCRIPTION
## 背景

`task apply` 実行時に nix-darwin 構成のビルドが以下のエラーで失敗していた。

```
error: path '.../configs/claude/hooks/enforce-narrative-pr.sh' does not exist
```

## 原因

コミット `f2cb498` でフック `enforce-narrative-pr.sh` を `pr-submission-via-skill.sh` へ改称したが、`claude.nix` の `install` 参照が旧名称のまま残っていた。home-manager のアクティベーション評価時に存在しないパスを参照し、ビルドが落ちていた。

`configs/claude/settings.json` のフックパスは改称時に新名称へ更新済みだったため、`claude.nix` 側の参照だけが取り残された格好になっていた。

## 変更

- `nix-darwin/module/claude.nix` — `install` 参照を `pr-submission-via-skill.sh` に更新
- `nix-os/modules/claude.nix` — NixOS 側にも同じ漏れがあったため同様に更新

## 確認

`nix build --dry-run` でエラーが解消し、derivation まで評価が通ることを確認した。