### PR TITLE
fix(claude): hook の存在しない notify decision を additionalContext へ修正

### DIFF
--- a/configs/claude/hooks/clean-comment-out.sh
+++ b/configs/claude/hooks/clean-comment-out.sh
@@ -8,9 +8,7 @@
 # additionalContext による注入は会話へ文章を追加するだけで、ツール実行を
 # 強制しない。そのためメッセージは明示的な指示で書く。
 #
-# 注入は hookSpecificOutput.additionalContext で行う。旧実装は存在しない
-# "decision": "notify" を返しており、Claude Code から黙って無視されていた
-# (notify という decision は hook 仕様にそもそも存在しない)。
+# 注入は hookSpecificOutput.additionalContext で行う。
 # see: https://code.claude.com/docs/en/hooks#posttooluse-decision-control
 #
 # 非ソースファイル (設定 / ドキュメント / データ) はスキップする。コメント整理は

--- a/configs/claude/hooks/clean-comment-out.sh
+++ b/configs/claude/hooks/clean-comment-out.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
-# clean-comment-out.sh - PostToolUse hook for Claude Code
-# After a Write or Edit on a source file, injects a mandatory instruction to
-# execute the clean__comment_out skill so that meaningless comments and
-# commented-out dead code are removed while valuable comments (Why / design
-# rationale / TODO|FIXME|HACK|XXX markers / public-interface docs) are kept.
+# clean-comment-out.sh - Claude Code 用 PostToolUse hook
+# ソースファイルへの Write/Edit の後に、clean__comment_out スキルの実行を促す
+# 必須指示を注入する。これにより、意味のないコメントやコメントアウトされた
+# デッドコードが削除され、価値あるコメント (Why / 設計判断 /
+# TODO|FIXME|HACK|XXX マーカー / 公開インターフェースのドキュメント) は残る。
 #
-# The message uses explicit instructions because injecting additionalContext
-# only adds text to the conversation — it does not force tool execution.
+# additionalContext による注入は会話へ文章を追加するだけで、ツール実行を
+# 強制しない。そのためメッセージは明示的な指示で書く。
 #
-# Injection is done via hookSpecificOutput.additionalContext. The previous
-# implementation returned a non-existent "decision": "notify", which Claude
-# Code silently ignored (no "notify" decision exists in the hook spec).
+# 注入は hookSpecificOutput.additionalContext で行う。旧実装は存在しない
+# "decision": "notify" を返しており、Claude Code から黙って無視されていた
+# (notify という decision は hook 仕様にそもそも存在しない)。
+# see: https://code.claude.com/docs/en/hooks#posttooluse-decision-control
 #
-# Non-source files (config / docs / data) are skipped: the cleanup concerns
-# code comments, and triggering on every Write/Edit (e.g. markdown, json)
-# would produce noise.
+# 非ソースファイル (設定 / ドキュメント / データ) はスキップする。コメント整理は
+# コードコメントが対象であり、すべての Write/Edit (例: markdown, json) で発火
+# させるとノイズになるため。
 
 set -euo pipefail
 
@@ -30,9 +31,9 @@ if [[ -z "$file_path" ]]; then
   exit 0
 fi
 
-# Only trigger on source-code files. Comment-cleanup judgment (Why vs What,
-# dead code, doc comments, markers) applies to programming languages, not to
-# config / docs / data files.
+# ソースコードファイルのみで発火する。コメント整理の判断 (Why か What か、
+# デッドコード、ドキュメントコメント、マーカー) はプログラミング言語に適用され、
+# 設定 / ドキュメント / データファイルには適用されないため。
 case "$file_path" in
   *.rs | *.go | *.py | *.ts | *.tsx | *.js | *.jsx | *.java | *.kt | *.kts \
     | *.c | *.h | *.cpp | *.cc | *.hpp | *.cs | *.rb | *.php | *.swift \
@@ -44,10 +45,10 @@ case "$file_path" in
     ;;
 esac
 
-# Emit a mandatory instruction to execute the comment-cleanup workflow.
+# コメント整理ワークフローの実行を促す必須指示を出力する。
 jq -n --arg path "$file_path" '{
   "hookSpecificOutput": {
     "hookEventName": "PostToolUse",
-    "additionalContext": ("A source file was just written or edited: " + $path + "\n\n[MANDATORY ACTION REQUIRED] You MUST now execute the clean__comment_out skill on the file(s) you just changed. Do NOT skip this. Do NOT ask the user for confirmation.\n\nThe clean__comment_out skill removes meaningless comments and commented-out dead code, while keeping valuable comments. Apply it now:\n1. Identify the comments in the file(s) you just edited.\n2. DELETE: comments restating what the code obviously does (What), and commented-out old code (dead code).\n3. KEEP: comments explaining WHY (rationale / constraints / tradeoffs), TODO/FIXME/HACK/XXX markers, and public-interface documentation comments.\n4. When in doubt, keep the comment.\n5. Edit only comments — never change code behavior, and only touch files you just modified.\n\nDo NOT continue with other tasks until the comment cleanup of the just-edited file(s) is complete.")
+    "additionalContext": ("ソースファイルが Write/Edit されました: " + $path + "\n\n[必須アクション] いま変更したファイルに対して、ただちに clean__comment_out スキルを実行しなければならない。省略してはならない。ユーザーへの確認も不要である。\n\nclean__comment_out スキルは、意味のないコメントとコメントアウトされたデッドコードを削除し、価値あるコメントは残す。いま次を適用すること:\n1. いま編集したファイルのコメントを洗い出す。\n2. 削除する: コードを見れば自明な内容 (What) を述べただけのコメント、コメントアウトされた古いコード (デッドコード)。\n3. 残す: なぜ (Why) を説明するコメント (設計判断 / 制約 / トレードオフ)、TODO/FIXME/HACK/XXX マーカー、公開インターフェースのドキュメントコメント。\n4. 迷ったらコメントを残す。\n5. コメントのみを編集する — コードの挙動は変えず、いま変更したファイルだけを対象にする。\n\nいま編集したファイルのコメント整理が完了するまで、他のタスクへ進んではならない。")
   }
 }'

--- a/configs/claude/hooks/clean-comment-out.sh
+++ b/configs/claude/hooks/clean-comment-out.sh
@@ -5,8 +5,12 @@
 # commented-out dead code are removed while valuable comments (Why / design
 # rationale / TODO|FIXME|HACK|XXX markers / public-interface docs) are kept.
 #
-# The message uses explicit instructions because the "notify" decision only
-# injects text into the conversation — it does not force tool execution.
+# The message uses explicit instructions because injecting additionalContext
+# only adds text to the conversation — it does not force tool execution.
+#
+# Injection is done via hookSpecificOutput.additionalContext. The previous
+# implementation returned a non-existent "decision": "notify", which Claude
+# Code silently ignored (no "notify" decision exists in the hook spec).
 #
 # Non-source files (config / docs / data) are skipped: the cleanup concerns
 # code comments, and triggering on every Write/Edit (e.g. markdown, json)
@@ -42,6 +46,8 @@ esac
 
 # Emit a mandatory instruction to execute the comment-cleanup workflow.
 jq -n --arg path "$file_path" '{
-  "decision": "notify",
-  "message": ("A source file was just written or edited: " + $path + "\n\n[MANDATORY ACTION REQUIRED] You MUST now execute the clean__comment_out skill on the file(s) you just changed. Do NOT skip this. Do NOT ask the user for confirmation.\n\nThe clean__comment_out skill removes meaningless comments and commented-out dead code, while keeping valuable comments. Apply it now:\n1. Identify the comments in the file(s) you just edited.\n2. DELETE: comments restating what the code obviously does (What), and commented-out old code (dead code).\n3. KEEP: comments explaining WHY (rationale / constraints / tradeoffs), TODO/FIXME/HACK/XXX markers, and public-interface documentation comments.\n4. When in doubt, keep the comment.\n5. Edit only comments — never change code behavior, and only touch files you just modified.\n\nDo NOT continue with other tasks until the comment cleanup of the just-edited file(s) is complete.")
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": ("A source file was just written or edited: " + $path + "\n\n[MANDATORY ACTION REQUIRED] You MUST now execute the clean__comment_out skill on the file(s) you just changed. Do NOT skip this. Do NOT ask the user for confirmation.\n\nThe clean__comment_out skill removes meaningless comments and commented-out dead code, while keeping valuable comments. Apply it now:\n1. Identify the comments in the file(s) you just edited.\n2. DELETE: comments restating what the code obviously does (What), and commented-out old code (dead code).\n3. KEEP: comments explaining WHY (rationale / constraints / tradeoffs), TODO/FIXME/HACK/XXX markers, and public-interface documentation comments.\n4. When in doubt, keep the comment.\n5. Edit only comments — never change code behavior, and only touch files you just modified.\n\nDo NOT continue with other tasks until the comment cleanup of the just-edited file(s) is complete.")
+  }
 }'

--- a/configs/claude/hooks/recommend-tasks.sh
+++ b/configs/claude/hooks/recommend-tasks.sh
@@ -5,8 +5,6 @@
 # 注入は hookSpecificOutput.additionalContext で行う。これは exit 0 時に
 # PreToolUse が解釈する唯一の「非ブロッキングなコンテキスト注入」フィールドで、
 # ツール実行を止めずに Claude へ文章を届ける。
-# 旧実装は存在しない "decision": "notify" を返しており、Claude Code から
-# 黙って無視されていた (notify という decision は仕様上どのイベントにも無い)。
 # see: https://code.claude.com/docs/en/hooks#pretooluse-decision-control
 
 set -euo pipefail

--- a/configs/claude/hooks/recommend-tasks.sh
+++ b/configs/claude/hooks/recommend-tasks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# recommend-tasks.sh - PreToolUse hook for Claude Code
+# recommend-tasks.sh - Claude Code 用 PreToolUse hook
 # Write/Edit の実行前に、TaskCreate での進捗管理を促すメッセージを注入する。
 #
 # 注入は hookSpecificOutput.additionalContext で行う。これは exit 0 時に
@@ -7,6 +7,7 @@
 # ツール実行を止めずに Claude へ文章を届ける。
 # 旧実装は存在しない "decision": "notify" を返しており、Claude Code から
 # 黙って無視されていた (notify という decision は仕様上どのイベントにも無い)。
+# see: https://code.claude.com/docs/en/hooks#pretooluse-decision-control
 
 set -euo pipefail
 

--- a/configs/claude/hooks/recommend-tasks.sh
+++ b/configs/claude/hooks/recommend-tasks.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 # recommend-tasks.sh - PreToolUse hook for Claude Code
-# Sends a notify message before every Write/Edit call,
-# requiring Claude to use TaskCreate for progress tracking.
+# Write/Edit の実行前に、TaskCreate での進捗管理を促すメッセージを注入する。
+#
+# 注入は hookSpecificOutput.additionalContext で行う。これは exit 0 時に
+# PreToolUse が解釈する唯一の「非ブロッキングなコンテキスト注入」フィールドで、
+# ツール実行を止めずに Claude へ文章を届ける。
+# 旧実装は存在しない "decision": "notify" を返しており、Claude Code から
+# 黙って無視されていた (notify という decision は仕様上どのイベントにも無い)。
 
 set -euo pipefail
 
@@ -13,6 +18,8 @@ if [[ "$tool_name" != "Write" && "$tool_name" != "Edit" ]]; then
 fi
 
 jq -n '{
-  "decision": "notify",
-  "message": "[MANDATORY ACTION REQUIRED] You MUST use TaskCreate before writing or editing files. If you have not created Tasks yet, stop and create them NOW.\n\n1. Break down your work into trackable steps with TaskCreate\n2. Mark tasks as in_progress before starting each step\n3. Mark tasks as completed when done\n\nDo NOT proceed with Write/Edit without Tasks."
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "additionalContext": "[ERROR] TaskCreate なしの Write/Edit は禁止されている。\n\nファイルを編集する前に、必ず TaskCreate で作業を追跡可能なステップへ分解しなければならない。タスク未作成のままの編集は規約違反である。\n\n1. TaskCreate で作業を分解する\n2. 各ステップの開始前に in_progress へ更新する\n3. 完了したら completed へ更新する\n\nまだタスクを作成していないなら、ただちに編集を中断し、いま TaskCreate を実行すること。"
+  }
 }'

--- a/configs/claude/hooks/trigger-ci-fix.sh
+++ b/configs/claude/hooks/trigger-ci-fix.sh
@@ -9,9 +9,7 @@
 # 強制しない。そのため、Claude が即座に行動する確度を上げるよう、メッセージは
 # 明示的かつ段階的な手順で書く。
 #
-# 注入は hookSpecificOutput.additionalContext で行う。旧実装は存在しない
-# "decision": "notify" を返しており、Claude Code から黙って無視されていた
-# (notify という decision は hook 仕様にそもそも存在しない)。
+# 注入は hookSpecificOutput.additionalContext で行う。
 # see: https://code.claude.com/docs/en/hooks#posttooluse-decision-control
 
 set -euo pipefail

--- a/configs/claude/hooks/trigger-ci-fix.sh
+++ b/configs/claude/hooks/trigger-ci-fix.sh
@@ -5,10 +5,14 @@
 # monitored and fixed without user intervention. That skill owns the
 # monitor-and-fix loop and delegates each repair pass to rescue__ci_failure.
 #
-# The message uses explicit, step-by-step instructions because the "notify"
-# decision only injects text into the conversation — it does not force tool
-# execution. Concrete instructions maximize the likelihood that Claude will
-# act on the message immediately.
+# The message uses explicit, step-by-step instructions because injecting
+# additionalContext only adds text to the conversation — it does not force
+# tool execution. Concrete instructions maximize the likelihood that Claude
+# will act on the message immediately.
+#
+# Injection is done via hookSpecificOutput.additionalContext. The previous
+# implementation returned a non-existent "decision": "notify", which Claude
+# Code silently ignored (no "notify" decision exists in the hook spec).
 
 set -euo pipefail
 
@@ -55,6 +59,8 @@ fi
 
 # Emit a mandatory instruction to execute the CI fix workflow.
 jq -n --arg ctx "$trigger_context" '{
-  "decision": "notify",
-  "message": ($ctx + "\n\n[MANDATORY ACTION REQUIRED] You MUST now execute the monitor__ci_status skill immediately. Do NOT skip this. Do NOT ask the user for confirmation. This is required by the project rules in CLAUDE.md.\n\nThe monitor__ci_status skill owns the monitor-and-fix loop; it polls CI and, on failure, invokes rescue__ci_failure for each repair pass. Execute these steps NOW:\n1. Get the current branch and PR number:\n   BRANCH=$(git branch --show-current)\n   PR_NUMBER=$(gh pr view \"$BRANCH\" --json number --jq \".number\")\n2. Wait for CI checks to be registered (poll for up to 60 seconds)\n3. Poll CI status every 30 seconds until all checks complete (timeout: 30 min)\n4. If all checks pass, report success\n5. If any check fails, invoke rescue__ci_failure (it reads logs with gh run view <run_id> --log-failed, fixes the code, commits, and pushes)\n6. Repeat from step 2 (max 5 iterations)\n\nDo NOT continue with any other task until this CI monitoring workflow is complete.")
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": ($ctx + "\n\n[MANDATORY ACTION REQUIRED] You MUST now execute the monitor__ci_status skill immediately. Do NOT skip this. Do NOT ask the user for confirmation. This is required by the project rules in CLAUDE.md.\n\nThe monitor__ci_status skill owns the monitor-and-fix loop; it polls CI and, on failure, invokes rescue__ci_failure for each repair pass. Execute these steps NOW:\n1. Get the current branch and PR number:\n   BRANCH=$(git branch --show-current)\n   PR_NUMBER=$(gh pr view \"$BRANCH\" --json number --jq \".number\")\n2. Wait for CI checks to be registered (poll for up to 60 seconds)\n3. Poll CI status every 30 seconds until all checks complete (timeout: 30 min)\n4. If all checks pass, report success\n5. If any check fails, invoke rescue__ci_failure (it reads logs with gh run view <run_id> --log-failed, fixes the code, commits, and pushes)\n6. Repeat from step 2 (max 5 iterations)\n\nDo NOT continue with any other task until this CI monitoring workflow is complete.")
+  }
 }'

--- a/configs/claude/hooks/trigger-ci-fix.sh
+++ b/configs/claude/hooks/trigger-ci-fix.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-# trigger-ci-fix.sh - PostToolUse hook for Claude Code
-# After `git push` or `gh pr create`, injects a mandatory instruction to
-# execute the monitor__ci_status skill so that CI failures are automatically
-# monitored and fixed without user intervention. That skill owns the
-# monitor-and-fix loop and delegates each repair pass to rescue__ci_failure.
+# trigger-ci-fix.sh - Claude Code 用 PostToolUse hook
+# `git push` または `gh pr create` の後に、monitor__ci_status スキルの実行を
+# 促す必須指示を注入する。これにより CI の失敗がユーザー介入なしに監視・修正
+# される。監視と修正のループは monitor__ci_status が所有し、各修復パスは
+# rescue__ci_failure へ委譲される。
 #
-# The message uses explicit, step-by-step instructions because injecting
-# additionalContext only adds text to the conversation — it does not force
-# tool execution. Concrete instructions maximize the likelihood that Claude
-# will act on the message immediately.
+# additionalContext による注入は会話へ文章を追加するだけで、ツール実行を
+# 強制しない。そのため、Claude が即座に行動する確度を上げるよう、メッセージは
+# 明示的かつ段階的な手順で書く。
 #
-# Injection is done via hookSpecificOutput.additionalContext. The previous
-# implementation returned a non-existent "decision": "notify", which Claude
-# Code silently ignored (no "notify" decision exists in the hook spec).
+# 注入は hookSpecificOutput.additionalContext で行う。旧実装は存在しない
+# "decision": "notify" を返しており、Claude Code から黙って無視されていた
+# (notify という decision は hook 仕様にそもそも存在しない)。
+# see: https://code.claude.com/docs/en/hooks#posttooluse-decision-control
 
 set -euo pipefail
 
@@ -28,7 +28,7 @@ if [[ -z "$command" ]]; then
   exit 0
 fi
 
-# Check if the command is a git push or gh pr create
+# コマンドが git push か gh pr create かを判定する
 is_git_push=false
 is_gh_pr_create=false
 
@@ -44,23 +44,23 @@ if [[ "$is_git_push" == "false" && "$is_gh_pr_create" == "false" ]]; then
   exit 0
 fi
 
-# Check if the tool execution succeeded (exit code 0)
+# ツール実行が成功したか (exit code 0) を確認する
 exit_code="$(echo "$input" | jq -r '.tool_output.exit_code // .tool_output.exitCode // "0"')"
 if [[ "$exit_code" != "0" ]]; then
   exit 0
 fi
 
-# Build a contextual trigger description
+# 発火コンテキストの説明文を組み立てる
 if [[ "$is_gh_pr_create" == "true" ]]; then
-  trigger_context="A PR was just created."
+  trigger_context="PR が作成されました。"
 else
-  trigger_context="Commits were just pushed to the PR branch."
+  trigger_context="PR ブランチへ commit が push されました。"
 fi
 
-# Emit a mandatory instruction to execute the CI fix workflow.
+# CI 修正ワークフローの実行を促す必須指示を出力する。
 jq -n --arg ctx "$trigger_context" '{
   "hookSpecificOutput": {
     "hookEventName": "PostToolUse",
-    "additionalContext": ($ctx + "\n\n[MANDATORY ACTION REQUIRED] You MUST now execute the monitor__ci_status skill immediately. Do NOT skip this. Do NOT ask the user for confirmation. This is required by the project rules in CLAUDE.md.\n\nThe monitor__ci_status skill owns the monitor-and-fix loop; it polls CI and, on failure, invokes rescue__ci_failure for each repair pass. Execute these steps NOW:\n1. Get the current branch and PR number:\n   BRANCH=$(git branch --show-current)\n   PR_NUMBER=$(gh pr view \"$BRANCH\" --json number --jq \".number\")\n2. Wait for CI checks to be registered (poll for up to 60 seconds)\n3. Poll CI status every 30 seconds until all checks complete (timeout: 30 min)\n4. If all checks pass, report success\n5. If any check fails, invoke rescue__ci_failure (it reads logs with gh run view <run_id> --log-failed, fixes the code, commits, and pushes)\n6. Repeat from step 2 (max 5 iterations)\n\nDo NOT continue with any other task until this CI monitoring workflow is complete.")
+    "additionalContext": ($ctx + "\n\n[必須アクション] ただちに monitor__ci_status スキルを実行しなければならない。省略してはならない。ユーザーへの確認も不要である。これは CLAUDE.md のプロジェクト規約で要求されている。\n\nmonitor__ci_status スキルは監視と修正のループを所有し、CI をポーリングして失敗時には各修復パスで rescue__ci_failure を起動する。いま次の手順を実行すること:\n1. 現在のブランチと PR 番号を取得する:\n   BRANCH=$(git branch --show-current)\n   PR_NUMBER=$(gh pr view \"$BRANCH\" --json number --jq \".number\")\n2. CI チェックが登録されるまで待つ (最大 60 秒ポーリング)\n3. 全チェック完了まで 30 秒ごとに CI 状態をポーリングする (タイムアウト: 30 分)\n4. 全チェックがパスしたら成功を報告する\n5. いずれかが失敗したら rescue__ci_failure を起動する (gh run view <run_id> --log-failed でログを読み、コードを修正し、commit して push する)\n6. 手順 2 から繰り返す (最大 5 回)\n\nこの CI 監視ワークフローが完了するまで、他のタスクへ進んではならない。")
   }
 }'


### PR DESCRIPTION
## 概要

Claude Code の hook が返していた、仕様上存在しない `"decision": "notify"` を、公式サポートされる `hookSpecificOutput.additionalContext` へ修正する。これにより hook のメッセージが実際に会話へ注入されるようになる。

## 背景

「`recommend-tasks.sh` が動いていないようだ」という指摘を起点に、過去ログ (`~/.claude/projects/` の全プロジェクト transcript) を横断調査した。その結果、`recommend-tasks.sh` のメッセージ文字列の出現はすべて「ソースファイルを Read した添付」由来であり、hook が会話へ注入した本物のレコードは **0 件**だった。`hookEventName` や `"decision":"notify"` の注入痕跡もログ上に一切存在しなかった。

同じ `"decision": "notify"` を使う hook が他に 2 つ (`trigger-ci-fix.sh` / `clean-comment-out.sh`) あり、いずれも同手法で注入実績 0 件と確認した。

## 課題

`notify` という decision 値は hook 仕様にそもそも存在しない (公式ドキュメントで確認)。exit 0 時に未知フィールドは黙って無視されるため、これらの hook は「起動・成功はするが、出力が一切無視される」状態だった。結果として、

- `recommend-tasks.sh`: Write/Edit 前の TaskCreate 促しが一度も効いていない
- `trigger-ci-fix.sh`: `git push` / `gh pr create` 後の CI 監視フロー (`monitor__ci_status`) の自動起点が機能していない
- `clean-comment-out.sh`: 編集後のコメント整理フローの自動起点が機能していない

## 目標

### 必須項目

- 3 つの hook の出力を、実際に会話へ注入される正しいフィールドへ修正する
- `recommend-tasks.sh` のメッセージを日本語化し、ERROR / 禁止の強い表現へ変更する

### 範囲外

- `~/.claude/` への反映 (`task apply` が必要 / sudo のため別途ユーザーが実施)
- hook の発火条件やメッセージ本文の根本的な見直し (今回は伝達手段の修正に限定)

## 採用手法

非ブロッキングでコンテキストを注入する公式手段は `hookSpecificOutput.additionalContext` のみ。PreToolUse / PostToolUse の双方が対応していることを公式ドキュメントで確認した。Write/Edit を止めずにメッセージだけを届けたいという元の意図 (notify=やわらかい通知) にも合致する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: `hookSpecificOutput.additionalContext` (採用) | 公式サポート / 非ブロッキング / 元の意図に一致 | 毎編集ごとに注入が入る |
| B: `permissionDecision: deny` / exit 2 でブロック | 強制力が最大 | 「タスク作成済みか」を hook が判定できず全 Write を阻害する |
| C: hook を削除 | 標準の TaskCreate リマインダーと重複解消 | ユーザーは強い促しの継続を希望 |

### 採用理由

ユーザーは「hook を残し、強い表現で促す」方針を選択した。全 Write をブロックする B は判定不能で破綻するため、伝達手段を `additionalContext` に正すのが最小かつ確実な修正である。

## 変更箇所

- `configs/claude/hooks/recommend-tasks.sh`: 出力を `additionalContext` 化し、メッセージを日本語・ERROR/禁止の強い表現へ変更
- `configs/claude/hooks/trigger-ci-fix.sh`: 出力を `additionalContext` 化 (CI 監視フローの起点)
- `configs/claude/hooks/clean-comment-out.sh`: 出力を `additionalContext` 化 (コメント整理フローの起点)

## 妥協と制限

- **毎編集ごとの注入**: `recommend-tasks.sh` は Write/Edit のたびに注入が入る。標準の TaskCreate リマインダーと一部重複するが、強い促しを残す方針を優先した。

## 検証方法

- 3 hook を疑似入力で実行し、`hookSpecificOutput.hookEventName` と `additionalContext` を含む有効な JSON を出力することを確認
- `recommend-tasks.sh` の出力に日本語と「ERROR」「TaskCreate」が含まれることを確認
- `clean-comment-out.sh` が非ソース (`.md`) を従来どおりスキップすることを確認
- live コードに `notify` が残らないこと (説明コメントのみ残置) を確認
- `validate-bash.sh` / `pr-submission-via-skill.sh` の `"decision": "reject"` は過去ログで実際に注入されている (pr-submission は 70 回) ことを確認し、対象外と判断

## 確認事項

- ⚠️ 反映には `nix-darwin/` (または `nix-os/`) での `task apply` (sudo) が必要。マージ後に手動実施が要る点を確認したい。
- ⚠️ `recommend-tasks.sh` を毎編集ごとに注入する方針で問題ないか (標準リマインダーとの重複)。

## 参考文献

- [Claude Code Hooks リファレンス](https://code.claude.com/docs/en/hooks)