### PR TITLE
refactor(claude): hook ファイル名を snake_case に統一

### DIFF
--- a/configs/claude/hooks/clean_comment_out.sh
+++ b/configs/claude/hooks/clean_comment_out.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# clean-comment-out.sh - Claude Code 用 PostToolUse hook
+# clean_comment_out.sh - Claude Code 用 PostToolUse hook
 # ソースファイルへの Write/Edit の後に、clean__comment_out スキルの実行を促す
 # 必須指示を注入する。これにより、意味のないコメントやコメントアウトされた
 # デッドコードが削除され、価値あるコメント (Why / 設計判断 /

--- a/configs/claude/hooks/pr_submission_via_skill.sh
+++ b/configs/claude/hooks/pr_submission_via_skill.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# pr-submission-via-skill.sh - PreToolUse hook for Claude Code
+# pr_submission_via_skill.sh - PreToolUse hook for Claude Code
 # Rejects direct `gh pr create` calls and instructs Claude to use the
 # submit__pull_request skill instead, which generates a structured,
 # narrative-style PR description automatically.

--- a/configs/claude/hooks/recommend_tasks.sh
+++ b/configs/claude/hooks/recommend_tasks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# recommend-tasks.sh - Claude Code 用 PreToolUse hook
+# recommend_tasks.sh - Claude Code 用 PreToolUse hook
 # Write/Edit の実行前に、TaskCreate での進捗管理を促すメッセージを注入する。
 #
 # 注入は hookSpecificOutput.additionalContext で行う。これは exit 0 時に

--- a/configs/claude/hooks/trigger_ci_fix.sh
+++ b/configs/claude/hooks/trigger_ci_fix.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# trigger-ci-fix.sh - Claude Code 用 PostToolUse hook
+# trigger_ci_fix.sh - Claude Code 用 PostToolUse hook
 # `git push` または `gh pr create` の後に、monitor__ci_status スキルの実行を
 # 促す必須指示を注入する。これにより CI の失敗がユーザー介入なしに監視・修正
 # される。監視と修正のループは monitor__ci_status が所有し、各修復パスは

--- a/configs/claude/hooks/validate_bash.sh
+++ b/configs/claude/hooks/validate_bash.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# validate-bash.sh - PreToolUse hook for Claude Code
+# validate_bash.sh - PreToolUse hook for Claude Code
 # Rejects prohibited commands with guidance on alternatives.
 #
 # Rules are declared as data arrays. To add a new rule, append one line

--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -60,11 +60,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/validate-bash.sh"
+            "command": "$HOME/.claude/hooks/validate_bash.sh"
           },
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/pr-submission-via-skill.sh"
+            "command": "$HOME/.claude/hooks/pr_submission_via_skill.sh"
           }
         ]
       },
@@ -73,7 +73,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/recommend-tasks.sh"
+            "command": "$HOME/.claude/hooks/recommend_tasks.sh"
           }
         ]
       }
@@ -84,7 +84,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/trigger-ci-fix.sh"
+            "command": "$HOME/.claude/hooks/trigger_ci_fix.sh"
           }
         ]
       },
@@ -93,7 +93,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/clean-comment-out.sh"
+            "command": "$HOME/.claude/hooks/clean_comment_out.sh"
           }
         ]
       }

--- a/configs/claude/skills/submit__pull_request/SKILL.md
+++ b/configs/claude/skills/submit__pull_request/SKILL.md
@@ -124,7 +124,7 @@ Phase 1 の分析結果で埋める。各セクションは「読み物」とし
 ### Phase 3: PR作成
 
 コマンドの末尾にバイパスマーカーを付与する。これは PreToolUse hook
-（pr-submission-via-skill.sh）がこのスキル経由の `gh pr create` を許可するための識別子です。
+（pr_submission_via_skill.sh）がこのスキル経由の `gh pr create` を許可するための識別子です。
 マーカーがないと hook がコマンドを拒否する。
 
 ```bash

--- a/nix-darwin/module/claude.nix
+++ b/nix-darwin/module/claude.nix
@@ -37,10 +37,10 @@
   # hook スクリプトをコピーとして配置（実行権限が必要）
   home.activation.claudeHooks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     run mkdir -p $HOME/.claude/hooks
-    run install -Dm755 ${../../configs/claude/hooks/validate-bash.sh} $HOME/.claude/hooks/validate-bash.sh
-    run install -Dm755 ${../../configs/claude/hooks/pr-submission-via-skill.sh} $HOME/.claude/hooks/pr-submission-via-skill.sh
-    run install -Dm755 ${../../configs/claude/hooks/trigger-ci-fix.sh} $HOME/.claude/hooks/trigger-ci-fix.sh
-    run install -Dm755 ${../../configs/claude/hooks/recommend-tasks.sh} $HOME/.claude/hooks/recommend-tasks.sh
-    run install -Dm755 ${../../configs/claude/hooks/clean-comment-out.sh} $HOME/.claude/hooks/clean-comment-out.sh
+    run install -Dm755 ${../../configs/claude/hooks/validate_bash.sh} $HOME/.claude/hooks/validate_bash.sh
+    run install -Dm755 ${../../configs/claude/hooks/pr_submission_via_skill.sh} $HOME/.claude/hooks/pr_submission_via_skill.sh
+    run install -Dm755 ${../../configs/claude/hooks/trigger_ci_fix.sh} $HOME/.claude/hooks/trigger_ci_fix.sh
+    run install -Dm755 ${../../configs/claude/hooks/recommend_tasks.sh} $HOME/.claude/hooks/recommend_tasks.sh
+    run install -Dm755 ${../../configs/claude/hooks/clean_comment_out.sh} $HOME/.claude/hooks/clean_comment_out.sh
   '';
 }

--- a/nix-os/modules/claude.nix
+++ b/nix-os/modules/claude.nix
@@ -27,9 +27,9 @@
   # hook スクリプトをコピーとして配置（実行権限が必要）
   home.activation.claudeHooks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     run mkdir -p $HOME/.claude/hooks
-    run install -Dm755 ${../../configs/claude/hooks/validate-bash.sh} $HOME/.claude/hooks/validate-bash.sh
-    run install -Dm755 ${../../configs/claude/hooks/pr-submission-via-skill.sh} $HOME/.claude/hooks/pr-submission-via-skill.sh
-    run install -Dm755 ${../../configs/claude/hooks/trigger-ci-fix.sh} $HOME/.claude/hooks/trigger-ci-fix.sh
-    run install -Dm755 ${../../configs/claude/hooks/clean-comment-out.sh} $HOME/.claude/hooks/clean-comment-out.sh
+    run install -Dm755 ${../../configs/claude/hooks/validate_bash.sh} $HOME/.claude/hooks/validate_bash.sh
+    run install -Dm755 ${../../configs/claude/hooks/pr_submission_via_skill.sh} $HOME/.claude/hooks/pr_submission_via_skill.sh
+    run install -Dm755 ${../../configs/claude/hooks/trigger_ci_fix.sh} $HOME/.claude/hooks/trigger_ci_fix.sh
+    run install -Dm755 ${../../configs/claude/hooks/clean_comment_out.sh} $HOME/.claude/hooks/clean_comment_out.sh
   '';
 }


### PR DESCRIPTION
## 背景

`configs/claude/hooks/` 配下のフックスクリプトだけが kebab-case (`clean-comment-out.sh` など) で、リポジトリ全体の命名規約である snake_case から外れていた。スキルディレクトリやルールファイルは snake_case で統一されており、フックのみ規約違反の状態が残っていた。

## 変更内容

5 つの hook ファイルを kebab-case から snake_case へリネームした。

| 旧 | 新 |
|---|---|
| `clean-comment-out.sh` | `clean_comment_out.sh` |
| `pr-submission-via-skill.sh` | `pr_submission_via_skill.sh` |
| `recommend-tasks.sh` | `recommend_tasks.sh` |
| `trigger-ci-fix.sh` | `trigger_ci_fix.sh` |
| `validate-bash.sh` | `validate_bash.sh` |

あわせて参照箇所をすべて追従させた:

- `configs/claude/settings.json` の hooks コマンドパス
- `nix-darwin/module/claude.nix` / `nix-os/modules/claude.nix` の `install` 配布先
- 各 hook 先頭のヘッダコメント (自己参照するファイル名)
- `submit__pull_request/SKILL.md` の説明文中の参照

## 判断の根拠

- バイパスマーカー `@pr-submission-via-skill-bypass` はファイル名ではなく、スキルと hook が共有する**契約文字列**であるため変更していない。ここを変えると `submit__pull_request` 経由の `gh pr create` が hook に拒否されるリスクがある。
- リネームは `git mv` で行い、履歴の追跡性を維持した (diff 上は rename として認識されている)。

## 確認事項

- `configs/claude/` の変更は配布先の `~/.claude/` に反映するため `task apply` (sudo) が必要。本 PR マージ後にユーザー環境で適用すること。