### PR TITLE
feat(nix-darwin): lazynix と hisui を宣言的に追加

### DIFF
--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -58,6 +58,21 @@
         "type": "github"
       }
     },
+    "crane": {
+      "locked": {
+        "lastModified": 1766194365,
+        "narHash": "sha256-4AFsUZ0kl6MXSm4BaQgItD0VGlEKR3iq7gIaL7TjBvc=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7d8ec2c71771937ab99790b45e6d9b93d15d9379",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -76,6 +91,63 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "hisui": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775471498,
+        "narHash": "sha256-Y2Z6IOK1p3rugAUKjOyXbgBayzMbZOdmY/87zfKeaKI=",
+        "owner": "shunsock",
+        "repo": "hisui",
+        "rev": "e4cf64f8770891b1f1fc81814e8f9efc18eee5ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shunsock",
+        "repo": "hisui",
         "type": "github"
       }
     },
@@ -100,13 +172,35 @@
         "type": "github"
       }
     },
+    "lazynix": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781411518,
+        "narHash": "sha256-MjswPF7ke1cfT1bUfJir5ELonyOcggcgbOAFOECRih8=",
+        "owner": "shunsock",
+        "repo": "lazynix",
+        "rev": "d57120610328e8ef6d95a5d3b97761c3a27915d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shunsock",
+        "repo": "lazynix",
+        "type": "github"
+      }
+    },
     "llm-agents": {
       "inputs": {
         "blueprint": "blueprint",
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "systems": "systems",
+        "systems": "systems_3",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -194,7 +288,9 @@
     },
     "root": {
       "inputs": {
+        "hisui": "hisui",
         "home-manager": "home-manager",
+        "lazynix": "lazynix",
         "llm-agents": "llm-agents",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs_2",
@@ -202,6 +298,36 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -9,6 +9,14 @@
     home-manager.url = "github:nix-community/home-manager/release-25.11";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     llm-agents.url = "github:numtide/llm-agents.nix";
+    # lazynix は nixpkgs を nixos-25.11 にピンしており当方と一致するため follows で一本化する。
+    lazynix.url = "github:shunsock/lazynix";
+    lazynix.inputs.nixpkgs.follows = "nixpkgs";
+    # hisui 上流は nixos-25.05 ピンだが、その dotnet SDK は aarch64-darwin で
+    # configureNuget フェーズがクラッシュする。当方の nixos-25.11 に follows させて
+    # 新しい dotnet SDK でビルドする。
+    hisui.url = "github:shunsock/hisui";
+    hisui.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
@@ -19,6 +27,8 @@
       nix-darwin,
       home-manager,
       llm-agents,
+      lazynix,
+      hisui,
       ...
     }:
     let
@@ -42,6 +52,8 @@
         };
       };
       pkgsLlmAgents = llm-agents.packages.${system};
+      lazynixPkg = lazynix.packages.${system}.default;
+      hisuiPkg = hisui.packages.${system}.default;
 
       complexity = pkgs.rustPlatform.buildRustPackage rec {
         pname = "complexity";
@@ -146,6 +158,8 @@
                 inherit pkgsUnstable;
                 inherit pkgsLlmAgents;
                 inherit complexity;
+                inherit lazynixPkg;
+                inherit hisuiPkg;
                 inherit username;
                 inherit homeDirectory;
               };

--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -4,6 +4,8 @@
   pkgsUnstable,
   pkgsLlmAgents,
   complexity,
+  lazynixPkg,
+  hisuiPkg,
   username,
   homeDirectory,
   lib,
@@ -54,6 +56,8 @@
     ]
     ++ [
       complexity
+      lazynixPkg
+      hisuiPkg
       pkgsLlmAgents.claude-code
       pkgsUnstable.google-cloud-sdk
       pkgsUnstable.gws


### PR DESCRIPTION
## 概要

[lazynix (lnix)](https://github.com/shunsock/lazynix) と [hisui](https://github.com/shunsock/hisui) を nix-darwin の flake input として取り込み、`home.packages` で宣言的にインストールする。これまで lazynix は `nix profile` で命令的に入れていたが、flake.lock にピン留めしてバージョン管理・再現性・ロールバックを得る。

## 変更点

- `flake.nix`: `lazynix` / `hisui` を input に追加し、`packages.<system>.default` を `extraSpecialArgs` 経由で home-manager へ注入
- `home.nix`: `lazynixPkg` / `hisuiPkg` を `home.packages` に追加
- `flake.lock`: 両 input を解決

## 設計判断

- **lazynix は `inputs.nixpkgs.follows = "nixpkgs"`**: 上流が nixos-25.11 ピンで当方と一致するため、nixpkgs を一本化し評価・ストアの重複を避ける。
- **hisui も `follows`**: 上流は nixos-25.05 ピンだが、その dotnet SDK は aarch64-darwin で `buildDotnetModule` の configureNuget フェーズ (`dotnet new nugetconfig`) が `Abort trap: 6` でクラッシュする。当方の nixos-25.11 に follows させ、新しい dotnet SDK でビルドすることで解消した。

## 検証

- `task format` — 成功
- `task validate` (build + check) — 成功 (`all checks passed!`)

## 補足

- 反映には `task apply` (sudo) が必要。