### PR TITLE
chore(nix-darwin): メニューバーを常時表示する

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -104,7 +104,8 @@
             ];
 
             # macOS system defaults
-            system.defaults.NSGlobalDomain._HIHideMenuBar = true;
+            # メニューバーを常時表示する (自動的に隠さない)
+            system.defaults.NSGlobalDomain._HIHideMenuBar = false;
           }
 
           # Keyboard remapping configuration


### PR DESCRIPTION
## 背景

macOS のメニューバーが状況に応じて自動的に隠れてしまい、常に表示しておきたいという要望があった。

## 変更内容

`nix-darwin/flake.nix` の `system.defaults.NSGlobalDomain._HIHideMenuBar` を `true` から `false` に変更した。

`_HIHideMenuBar` は「メニューバーを自動的に隠す」フラグで、`false` にすることでメニューバーが常時表示される。キー名が二重否定 (Hide=false) で意図が読み取りにくいため、補足コメントを添えた。

## 確認事項

- `task format` 成功
- `task validate` (build + check) 成功

反映には `task apply` (sudo を伴う `darwin-rebuild switch`) が必要。