### PR TITLE
fix(claude): require_tasks hook の Task 判定をディレクトリ存在へ変更

### DIFF
--- a/configs/claude/hooks/require_tasks.sh
+++ b/configs/claude/hooks/require_tasks.sh
@@ -6,11 +6,16 @@
 # ハードゲート。以前は additionalContext による推奨だったが、非ブロッキング
 # ゆえに無視できてしまうため、permissionDecision: deny へ切り替えた。
 #
-# Task 有無の判定は $HOME/.claude/tasks/<session_id>/.highwatermark を見る。
-# この環境では Task は per-session の JSON ファイルとしてではなく、ロックと
-# 採番ハイウォーターマーク (.highwatermark) のみがこのディレクトリに置かれる。
-# .highwatermark は割り当て済み Task ID の最大値で、1 つでも TaskCreate すると
-# 1 以上になり、Task 未作成のセッションではディレクトリ自体が作られない。
+# Task 有無の判定は $HOME/.claude/tasks/<session_id> ディレクトリの存在で行う。
+# このディレクトリは最初の TaskCreate と同時刻 (秒単位一致) に生成され、Task を
+# 一度も作っていないセッションでは作られない。
+#
+# 当初は中の .highwatermark (割り当て済み Task ID の最大値) を読み >= 1 を要求して
+# いたが、.highwatermark は TaskCreate に同期して書かれず、観測した環境では
+# セッション中ずっと出現しなかった。一方で各 Task は <id>.json として TaskCreate と
+# 同期生成される。.highwatermark に依存すると TaskCreate 済みでも deny され続け、
+# モデルが Bash ヒアドキュメントでゲートを迂回する事象が起きた。そのため判定を
+# ディレクトリの存在 (= TaskCreate が一度でも走った同期シグナル) へ変更した。
 # session_id を得る環境変数は無いため、ペイロード stdin が唯一の取得元である。
 # see: https://code.claude.com/docs/en/hooks#pretooluse-decision-control
 
@@ -35,14 +40,9 @@ case "$file_path" in
   */.claude/plans/*) exit 0 ;;
 esac
 
-# このセッションで 1 つでも Task が採番されていれば (.highwatermark >= 1) 許可。
-highwatermark_file="$HOME/.claude/tasks/$session_id/.highwatermark"
-if [[ -f "$highwatermark_file" ]]; then
-  highwatermark="$(cat "$highwatermark_file" 2>/dev/null || echo 0)"
-  if [[ "$highwatermark" =~ ^[0-9]+$ ]] && (( highwatermark >= 1 )); then
-    exit 0
-  fi
-fi
+# このセッションで 1 つでも TaskCreate されていれば tasks ディレクトリが存在する。
+tasks_dir="$HOME/.claude/tasks/$session_id"
+[[ -d "$tasks_dir" ]] && exit 0
 
 # Task が 1 つも無い — ブロックする。
 jq -n '{


### PR DESCRIPTION
## 背景

`configs/claude/hooks/require_tasks.sh` は「編集前に必ず `TaskCreate` で作業を分解する」規約を `permissionDecision: deny` で強制する PreToolUse hook (Write|Edit)。トランスクリプトログを調査したところ、実際に発火・ブロックはしているものの、**`TaskCreate` 成功後の Write/Edit まで誤って deny する不具合**が見つかった。

## 根本原因

hook は Task の有無を `$HOME/.claude/tasks/<session_id>/.highwatermark >= 1` で判定していた。しかし `.highwatermark` は **`TaskCreate` に同期して書き込まれない**。

ログ (秒精度の birth time) での実測:

| セッション | TaskCreate | dir / `.lock` 生成 | `.highwatermark` 生成 |
|---|---|---|---|
| remove-unused-ci | 21:20:52 | **21:20:52**（同時） | 21:21:59（+67s） |
| issue-655 | 13:47:55 | **13:47:55**（同時） | 13:49:10（+75s） |

さらに本調査セッションでは、`TaskCreate` 後に `1.json` `2.json` `3.json` が即座に生成された一方、`.highwatermark` は **200 秒待っても出現しなかった**。つまりこの環境では `.highwatermark` 依存の hook が `TaskCreate` 済みでも Write/Edit を deny し続ける。

その結果、ブロックされたモデルは hook が `Write|Edit` のみを対象とすることを突いて、`Bash` の `cat > file` ヒアドキュメントでゲートを迂回していた（実ログで確認）。これではハードゲートが空洞化する。

## 変更内容

判定シグナルを、`TaskCreate` と**同期生成される** `$HOME/.claude/tasks/<session_id>` ディレクトリの存在へ変更:

```diff
-highwatermark_file="$HOME/.claude/tasks/$session_id/.highwatermark"
-if [[ -f "$highwatermark_file" ]]; then
-  highwatermark="$(cat "$highwatermark_file" 2>/dev/null || echo 0)"
-  if [[ "$highwatermark" =~ ^[0-9]+$ ]] && (( highwatermark >= 1 )); then
-    exit 0
-  fi
-fi
+tasks_dir="$HOME/.claude/tasks/$session_id"
+[[ -d "$tasks_dir" ]] && exit 0
```

Task を一度も作っていないセッションではディレクトリ自体が作られない（本セッション開始時に未作成状態でディレクトリ非存在を確認済み）ため、deny の意図は維持される。

## 検証

- `bash -n` / `shellcheck`: パス
- サンドボックス `HOME` でペイロード別に動作確認:
  - 非 Write/Edit → スキップ (exit 0)
  - `session_id` 欠落 → 許可
  - `.claude/plans/` 配下 → タスク無しでも許可
  - tasks ディレクトリ有り → **許可**（従来は誤 deny していたケース）
  - tasks ディレクトリ無し → deny (JSON 出力)

## 注意

`configs/claude/` はグローバル設定のソース。反映には `nix-darwin/` (または `nix-os/`) で `task apply` (sudo, Claude 実行不可) が必要。マージ後にユーザー側で apply されるまで、稼働中の `~/.claude/hooks/require_tasks.sh` は旧版のまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)