### PR TITLE
feat(claude): Task ゲートを in_progress 必須化し Stop hook で未完了を防止

### DIFF
--- a/configs/claude/hooks/block_stop_on_open_tasks.sh
+++ b/configs/claude/hooks/block_stop_on_open_tasks.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# block_stop_on_open_tasks.sh - Claude Code 用 Stop hook
+#
+# 未完了 (pending / in_progress) の Task が残ったままの停止をブロックする。
+# require_tasks.sh (編集前に in_progress を要求する PreToolUse ゲート) と対で
+# 機能し、「捨て Task を 1 つ in_progress にして放置」を防ぐ。停止しようとした
+# 時点で未完了 Task があれば、それらを片付ける (実作業を行う) まで停止できない。
+#
+# Task 状態は $HOME/.claude/tasks/<session_id>/<id>.json の .status を読む。
+# 形式と同期性は require_tasks.sh のヘッダコメント参照。
+# see: https://code.claude.com/docs/en/hooks#stop-and-subagentstop-decision-control
+
+set -euo pipefail
+
+input="$(cat)"
+
+# stop_hook_active が true の停止は、この hook 自身のブロックで再入した停止で
+# ある。ここで再びブロックすると無限ループになるため許可する。
+if echo "$input" | jq -e '.stop_hook_active == true' >/dev/null 2>&1; then
+  exit 0
+fi
+
+# session_id が取れない場合は、別セッションの状態で誤ってブロックしないよう
+# 安全側に倒して許可する。
+session_id="$(echo "$input" | jq -r '.session_id // empty')"
+[[ -z "$session_id" ]] && exit 0
+
+tasks_dir="$HOME/.claude/tasks/$session_id"
+[[ -d "$tasks_dir" ]] || exit 0
+
+# 未完了 Task (pending / in_progress) を subject 付きで集める。
+incomplete=""
+for task_json in "$tasks_dir"/*.json; do
+  [[ -f "$task_json" ]] || continue
+  line="$(jq -r 'select(.status == "pending" or .status == "in_progress") | "- [\(.status)] \(.subject)"' "$task_json" 2>/dev/null)"
+  [[ -n "$line" ]] && incomplete+="$line"$'\n'
+done
+
+[[ -z "$incomplete" ]] && exit 0
+
+reason="未完了の Task が残っている:
+${incomplete}
+各 Task は実際に作業を行って解決すること (作業せずに completed にしてはならない)。すべて片付けてから停止し直すこと。"
+
+jq -n --arg reason "$reason" '{
+  "decision": "block",
+  "reason": $reason
+}'

--- a/configs/claude/hooks/require_tasks.sh
+++ b/configs/claude/hooks/require_tasks.sh
@@ -1,21 +1,20 @@
 #!/bin/bash
 # require_tasks.sh - Claude Code 用 PreToolUse hook (Write|Edit)
 #
-# セッションに Task が 1 つも無い状態での Write/Edit を deny でブロックする。
-# 「編集の前に必ず TaskCreate で作業を分解する」という規約を強制するための
-# ハードゲート。以前は additionalContext による推奨だったが、非ブロッキング
-# ゆえに無視できてしまうため、permissionDecision: deny へ切り替えた。
+# in_progress な Task が 1 つも無い状態での Write/Edit を deny でブロックする。
+# 「編集を始める前に、その作業を担う Task を in_progress にする」という規約を
+# 強制するハードゲート。これにより「捨て Task を 1 つ作れば以降ずっと編集し放題」
+# という抜け穴を塞ぐ — 編集を続けるには常に in_progress な Task が要る。
 #
-# Task 有無の判定は $HOME/.claude/tasks/<session_id> ディレクトリの存在で行う。
-# このディレクトリは最初の TaskCreate と同時刻 (秒単位一致) に生成され、Task を
-# 一度も作っていないセッションでは作られない。
+# 判定は $HOME/.claude/tasks/<session_id>/<id>.json の .status を直接読む。
+# 実機検証の結果、アクティブセッション中は以下が成り立つ:
+#   - TaskCreate が <id>.json を同期生成し status="pending" を書く
+#   - TaskUpdate が同 json の .status を同期更新する (in_progress / completed)
+#   - status="deleted" にすると json ごと削除される
+# よって編集の瞬間の「現在 in_progress な Task」をディスクから確実に判定できる。
 #
-# 当初は中の .highwatermark (割り当て済み Task ID の最大値) を読み >= 1 を要求して
-# いたが、.highwatermark は TaskCreate に同期して書かれず、観測した環境では
-# セッション中ずっと出現しなかった。一方で各 Task は <id>.json として TaskCreate と
-# 同期生成される。.highwatermark に依存すると TaskCreate 済みでも deny され続け、
-# モデルが Bash ヒアドキュメントでゲートを迂回する事象が起きた。そのため判定を
-# ディレクトリの存在 (= TaskCreate が一度でも走った同期シグナル) へ変更した。
+# 過去に試した .highwatermark (割り当て済み Task ID の最大値) は、アクティブ
+# セッション中は書かれず終了時に遅延生成されると判明したため依存しない。
 # session_id を得る環境変数は無いため、ペイロード stdin が唯一の取得元である。
 # see: https://code.claude.com/docs/en/hooks#pretooluse-decision-control
 
@@ -40,15 +39,21 @@ case "$file_path" in
   */.claude/plans/*) exit 0 ;;
 esac
 
-# このセッションで 1 つでも TaskCreate されていれば tasks ディレクトリが存在する。
+# 現在 in_progress な Task が 1 つでもあれば許可する。
 tasks_dir="$HOME/.claude/tasks/$session_id"
-[[ -d "$tasks_dir" ]] && exit 0
+if [[ -d "$tasks_dir" ]]; then
+  for task_json in "$tasks_dir"/*.json; do
+    [[ -f "$task_json" ]] || continue
+    status="$(jq -r '.status // empty' "$task_json" 2>/dev/null)"
+    [[ "$status" == "in_progress" ]] && exit 0
+  done
+fi
 
-# Task が 1 つも無い — ブロックする。
+# in_progress な Task が無い — ブロックする。
 jq -n '{
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
     "permissionDecision": "deny",
-    "permissionDecisionReason": "TaskCreate なしの Write/Edit は禁止されている。\n\nファイルを編集する前に、必ず TaskCreate で作業を追跡可能なステップへ分解しなければならない。タスク未作成のままの編集は規約違反であり、この編集はブロックされた。\n\n1. TaskCreate で作業を分解する\n2. 各ステップの開始前に in_progress へ更新する\n3. 完了したら completed へ更新する\n\nいま TaskCreate を実行してから、編集をやり直すこと。"
+    "permissionDecisionReason": "in_progress な Task が無い状態での Write/Edit は禁止されている。\n\nファイルを編集する前に、その編集を担う Task を必ず in_progress にしなければならない。in_progress な Task が 1 つも無いままの編集は規約違反であり、この編集はブロックされた。\n\n1. まだ Task が無ければ TaskCreate で作業を分解する\n2. これから着手するステップの Task を TaskUpdate で in_progress にする\n3. そのステップが完了したら completed にする\n\nいま該当 Task を in_progress にしてから、編集をやり直すこと。"
   }
 }'

--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -97,6 +97,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/block_stop_on_open_tasks.sh"
+          }
+        ]
+      }
     ]
   },
   "extraKnownMarketplaces": {

--- a/nix-darwin/module/claude.nix
+++ b/nix-darwin/module/claude.nix
@@ -41,6 +41,7 @@
     run install -Dm755 ${../../configs/claude/hooks/pr_submission_via_skill.sh} $HOME/.claude/hooks/pr_submission_via_skill.sh
     run install -Dm755 ${../../configs/claude/hooks/trigger_ci_fix.sh} $HOME/.claude/hooks/trigger_ci_fix.sh
     run install -Dm755 ${../../configs/claude/hooks/require_tasks.sh} $HOME/.claude/hooks/require_tasks.sh
+    run install -Dm755 ${../../configs/claude/hooks/block_stop_on_open_tasks.sh} $HOME/.claude/hooks/block_stop_on_open_tasks.sh
     run install -Dm755 ${../../configs/claude/hooks/clean_comment_out.sh} $HOME/.claude/hooks/clean_comment_out.sh
   '';
 }

--- a/nix-os/modules/claude.nix
+++ b/nix-os/modules/claude.nix
@@ -31,6 +31,7 @@
     run install -Dm755 ${../../configs/claude/hooks/pr_submission_via_skill.sh} $HOME/.claude/hooks/pr_submission_via_skill.sh
     run install -Dm755 ${../../configs/claude/hooks/trigger_ci_fix.sh} $HOME/.claude/hooks/trigger_ci_fix.sh
     run install -Dm755 ${../../configs/claude/hooks/require_tasks.sh} $HOME/.claude/hooks/require_tasks.sh
+    run install -Dm755 ${../../configs/claude/hooks/block_stop_on_open_tasks.sh} $HOME/.claude/hooks/block_stop_on_open_tasks.sh
     run install -Dm755 ${../../configs/claude/hooks/clean_comment_out.sh} $HOME/.claude/hooks/clean_comment_out.sh
   '';
 }


### PR DESCRIPTION
## 概要

Claude Code の Task 強制 hook を「セッションに Task が 1 つでもあれば許可」から「**現在 in_progress な Task が 1 つ以上ある時だけ Write/Edit を許可**」へ強化し、あわせて未完了タスクを残したままの停止をブロックする Stop hook を追加する。

## 背景

「Edit の前に Task を作る規約が守られていない時がある気がする」という疑いから、過去の全 166 transcript を解析した。実際に Task 未作成のまま編集が成立しているセッションが多数見つかり、原因は時系列で 3 つに切り分けられた。

1. 旧 `recommend_tasks.sh` 時代（非ブロッキング・推奨のみ）→ モデルが無視できた
2. 第一次 deny 版（`.highwatermark` 判定）→ TaskCreate 後も deny が解けず、Bash ヒアドキュメントで迂回された
3. 現行のディレクトリ存在判定版 → 「セッションに Task が 1 つでもあれば以降ずっと編集し放題」という穴が残っていた

## 課題

現行のディレクトリ存在判定では、**捨て Task を 1 個作るだけでゲートが恒久的に無力化**する。CLAUDE.md が要求する「各ステップの開始前に in_progress へ更新し、完了したら completed にする」という能動的なタスク追跡を強制できていなかった。

加えて、Task 状態をディスクからどう読むかが不明確だった。過去に依存した `.highwatermark` はアクティブセッション中に書かれず（遅延生成）、これが第一次 deny 版を壊した原因でもあった。

## 目標

### 必須項目

- すべての Write/Edit が in_progress な Task の下でのみ実行されることを強制する
- 「捨て Task 1 個で編集し放題」の穴を塞ぐ
- in_progress を放置したまま終了する経路も塞ぐ
- 信頼できないシグナル（`.highwatermark`）に依存しない

### 範囲外

- サブエージェント固有のタスク強制（現状は親セッションの状態を継承する素直な挙動とする）
- `configs/claude/` の実環境への反映（`task apply` はユーザーが行う）

## 採用手法

実機検証で、アクティブセッション中の `~/.claude/tasks/<session>/<id>.json` の挙動を確認した。

- `TaskCreate` → `<id>.json` を**同期生成**し `status="pending"` を書く
- `TaskUpdate` → 同 json の `.status` を**同期更新**（in_progress / completed）
- `status=deleted` → json ごと削除
- `.highwatermark` → アクティブ中は書かれず、セッション終了時に遅延生成

よって編集の瞬間の「現在 in_progress な Task の有無」を json から確実に判定できる。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: in_progress な Task の存在を要求（採用） | 全 Edit が能動的タスク下で行われることを保証。1 論理変更が複数ファイルに跨っても 1 タスクでカバーでき churn が無い。json の status は同期書き込みで信頼できる | 最初の編集前に TaskCreate→in_progress の 2 手が必要 |
| B: Edit 1 回ごとに新規 TaskCreate を要求 | 規律は最強 | 1 論理変更=複数ファイルでタスクが乱立。唯一のカウンタ `.highwatermark` が遅延書き込みで信頼不可 |
| C: 現状維持（Task が存在すれば許可） | 実装が単純 | 捨て Task 1 個で無力化。今回の課題そのもの |

### 採用理由

A は「全 Edit が能動的タスクの下で行われる」を churn なく保証でき、判定が同期 json に基づくため信頼できる。B はタスク乱立に加え、依存する `.highwatermark` が信頼できないため不採用。

## 変更箇所

- `configs/claude/hooks/require_tasks.sh`:判定を「tasks ディレクトリ存在」から「`<id>.json` の `.status` に in_progress が 1 つ以上」へ変更。`.highwatermark` 非依存。session_id 空・plan ファイルの安全フォールバックは維持
- `configs/claude/hooks/block_stop_on_open_tasks.sh`:新規 Stop hook。未完了（pending/in_progress）Task が残ったままの停止を `decision:block` でブロック。`stop_hook_active` で無限ループ防止
- `configs/claude/settings.json`:hooks に Stop イベントを追加し新 hook を登録
- `nix-darwin/module/claude.nix`:新 hook の配布用 `install -Dm755` 行を追加
- `nix-os/modules/claude.nix`:同上

## 妥協と制限

- **最初の編集前に 2 手必要**:TaskCreate して in_progress にしてから編集、という順序を強制する。これは規約そのものであり意図的に受け入れる
- **サブエージェント**:payload の `session_id` が親と同一なら親の in_progress で通り、独自 ID なら自前タスクが要る。特別扱いせず素直に継承する
- **反映に `task apply` が必要**:`configs/claude/` の変更は sudo を伴う `task apply`（Claude 実行不可）までは反映されない

## 検証方法

- `bash -n` / `shellcheck`:両 hook ともパス（exit 0）
- サンプル payload による動作テスト 8 ケース全通過:空→deny / pending のみ→deny / in_progress→許可 / session 空→許可 / plan ファイル→許可 / Stop: in_progress 残→block / 全 completed→許可 / stop_hook_active→許可
- `task format` 成功、`task validate`（nix-darwin の build + check）全通過

## 確認事項

- ⚠️ 強制の粒度を「in_progress な Task の存在」とした点（B の「Edit ごとに新規 Task」ではなく）。これで意図する「Edit ごとに Task」を満たせているか
- ⚠️ サブエージェントを特別扱いせず親セッションの状態を継承させる挙動でよいか
- マージ後、各環境で `task apply` による反映が必要

## 参考文献

- 調査の発端と分析: 本リポジトリ内のセッションログ解析（require_tasks hook の発火状況）