### PR TITLE
feat(claude): nix-darwin 更新スキルを追加

### DIFF
--- a/.claude/skills/update__nix_darwin/SKILL.md
+++ b/.claude/skills/update__nix_darwin/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: update__nix_darwin
+description: >-
+  ユーザーが nix-darwin (macOS システム設定) の依存を更新したいときに起動する。
+  `nix-darwin/` で `task update` を実行して flake.lock を更新し、専用ブランチを
+  切ってコミットし push する。flake 依存の更新を 1 つの自律フローにまとめる。
+tools: Bash
+model: inherit
+---
+
+あなたは nix-darwin の依存更新を担当する。このスキルは `nix-darwin/` の flake 依存を
+更新し、専用ブランチに切ってコミット・push するまでを **1 つの自律フロー** として実行する。
+
+`task update` は内部で `nix flake update` を実行し、`nix-darwin/flake.lock` を更新する。
+**flake.lock の差分が出ない (= 更新がない) 場合は、ブランチを切らずにその旨を報告して終了する。**
+
+## 実行上の制約
+
+- このスキルは **`task apply` を実行しない**。apply は sudo を伴い Claude では実行できない
+  ため、適用はユーザーに依頼する (PR マージ後に手動で `task apply`)。
+- `git push --force` / `git push -f` は使わない。
+
+## 実行ステップ
+
+### フェーズ 1: 更新の実行
+
+リポジトリルートから `nix-darwin/` に移動し、flake 依存を更新する。
+
+```bash
+cd nix-darwin
+task update
+```
+
+### フェーズ 2: 差分の確認
+
+`flake.lock` に変更があるか確認する。
+
+```bash
+git -C "$(git rev-parse --show-toplevel)" status --porcelain nix-darwin/flake.lock
+```
+
+- 出力が空 (差分なし) → 更新は不要。ブランチを切らずに「更新なし」と報告して終了。
+- 差分あり → フェーズ 3 へ。
+
+### フェーズ 3: ブランチ作成・コミット・push
+
+直近の運用に合わせ、ブランチ名・コミットメッセージは `bump/nix` 系で統一する。
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git switch -c bump/nix
+git add nix-darwin/flake.lock
+git commit -m "bump: update nix"
+git push -u origin bump/nix
+```
+
+> 既に `bump/nix` ブランチが存在する場合は、日付などでサフィックスを付けて衝突を避ける
+> (例: `bump/nix-20260627`)。
+
+### フェーズ 4: 報告
+
+更新された input (例: `nixpkgs`, `nix-darwin`, `home-manager` など) を `flake.lock` の
+差分から要約し、push したブランチ名とともにユーザーへ報告する。PR 作成やマージ後の
+`task apply` (ユーザーが手動実行) を案内する。

--- a/.claude/skills/update__nix_darwin/SKILL.md
+++ b/.claude/skills/update__nix_darwin/SKILL.md
@@ -8,16 +8,14 @@ tools: Bash
 model: inherit
 ---
 
-あなたは nix-darwin の依存更新を担当する。このスキルは `nix-darwin/` の flake 依存を
-更新し、専用ブランチに切ってコミット・push するまでを **1 つの自律フロー** として実行する。
+あなたは nix-darwin の依存更新を担当する。このスキルは `nix-darwin/` の flake 依存を更新し、専用ブランチに切ってコミット・push するまでを **1 つの自律フロー** として実行する。
 
 `task update` は内部で `nix flake update` を実行し、`nix-darwin/flake.lock` を更新する。
 **flake.lock の差分が出ない (= 更新がない) 場合は、ブランチを切らずにその旨を報告して終了する。**
 
 ## 実行上の制約
 
-- このスキルは **`task apply` を実行しない**。apply は sudo を伴い Claude では実行できない
-  ため、適用はユーザーに依頼する (PR マージ後に手動で `task apply`)。
+- このスキルは **`task apply` を実行しない**。apply は sudo を伴い Claude では実行できないため、適用はユーザーに依頼する (PR マージ後に手動で `task apply`)。
 - `git push --force` / `git push -f` は使わない。
 
 ## 実行ステップ
@@ -54,11 +52,8 @@ git commit -m "bump: update nix"
 git push -u origin bump/nix
 ```
 
-> 既に `bump/nix` ブランチが存在する場合は、日付などでサフィックスを付けて衝突を避ける
-> (例: `bump/nix-20260627`)。
+> 既に `bump/nix` ブランチが存在する場合は、日付などでサフィックスを付けて衝突を避ける (例: `bump/nix-20260627`)。
 
 ### フェーズ 4: 報告
 
-更新された input (例: `nixpkgs`, `nix-darwin`, `home-manager` など) を `flake.lock` の
-差分から要約し、push したブランチ名とともにユーザーへ報告する。PR 作成やマージ後の
-`task apply` (ユーザーが手動実行) を案内する。
+更新された input (例: `nixpkgs`, `nix-darwin`, `home-manager` など) を `flake.lock` の差分から要約し、push したブランチ名とともにユーザーへ報告する。PR 作成やマージ後の `task apply` (ユーザーが手動実行) を案内する。


### PR DESCRIPTION
## 概要

`nix-darwin` (macOS システム設定) の flake 依存更新を定型作業からスキル化する
`update__nix_darwin` を、本リポジトリ専用の `.claude/skills/` に追加する。

## 背景

nix-darwin の依存更新は、これまで `cd nix-darwin && task update` で `flake.lock` を
更新し、ブランチを切って push する、という同じ手順を毎回手作業で繰り返してきた。
直近では PR #335 が `bump/nix` ブランチ・`bump: update nix` コミットで同じ流れを
踏んでいる。手順自体は単純だが定型的で、再現性を持って自律実行できると都合がよい。

## 課題

- 同一手順の手作業繰り返しは、ブランチ名・コミットメッセージの揺れを生みやすい。
- 「更新差分が無いとき (flake.lock に変化なし) は何もしない」という分岐判断を
  毎回人手で行っている。
- `task apply` は sudo を伴い Claude では実行できない制約があり、更新フローのどこまでを
  自動化してよいかが暗黙知になっている。

## 目標

### 必須項目

- `cd nix-darwin && task update` → 差分確認 → ブランチ作成・コミット・push までを
  1 つの自律フローとして定義する。
- `flake.lock` に差分が無い場合はブランチを切らずに終了する分岐を明文化する。
- `task apply` を含めず、適用はユーザーへ依頼する旨を明記する。

### 範囲外

- `task apply` の自動実行 (sudo 制約のため対象外)。
- グローバル配布 (`configs/claude/skills/`) への展開。本 PR は本リポジトリ専用の
  `.claude/skills/` に閉じる。

## 採用手法

既存スキル群の規約 (`動詞__対象` 命名、Markdown frontmatter + フェーズ構成の本文) に
そろえて単一の `SKILL.md` を追加する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: 本リポジトリ `.claude/skills/` に追加 (採用) | このリポジトリ作業時のみ有効で影響範囲が局所的 | 他プロジェクトからは使えない |
| B: `configs/claude/skills/` (グローバル配布) に追加 | 全プロジェクトで利用可能 | nix-darwin はこのリポジトリ固有のためグローバル汚染になる / `task apply` 必須で反映が重い |

### 採用理由

更新対象の `nix-darwin/` は本リポジトリ固有の資産であり、スキルもこのリポジトリで
作業するときにだけ意味を持つ。影響範囲を局所化できる A を採用した。

## 変更箇所

- `.claude/skills/update__nix_darwin/SKILL.md`: nix-darwin の flake 更新 → 差分確認 → ブランチ作成・コミット・push を行うスキル定義を新規追加。

## 妥協と制限

- **`task apply` 非対応**: sudo を伴い Claude では実行不可 (`.claude/rules/constraints.md`) のため、適用はユーザーが PR マージ後に手動で行う前提とし、スキルでは案内に留める。
- **ブランチ衝突時の手当て**: 既存 `bump/nix` がある場合は日付サフィックスで回避する運用をスキル本文に注記したが、自動採番までは行わない。

## 検証方法

- スキルファイルの frontmatter (`name` / `description` / `tools` / `model`) と本文の
  フェーズ構成が既存スキルの形式に一致することを確認。
- `nix-darwin/Taskfile.yml` の `update` タスクが `nix flake update` を実行し
  `flake.lock` を更新することを確認 (スキルの前提と整合)。

## 確認事項

- ⚠️ ブランチ名・コミットメッセージの規約を `bump/nix` 系で統一したが、現行運用と
  一致しているか (PR #335 に倣った)。
- ⚠️ 配置先を本リポジトリ `.claude/skills/` とした判断 (グローバル配布しない) でよいか。

## 参考文献

- [PR #335: bump/nix (直近の同種更新)](https://github.com/shunsock/dotfiles/pull/335)