### PR TITLE
fix(nix-darwin): docker formula の link 衝突で brew bundle が失敗する問題を修正

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -146,6 +146,24 @@
                 "wezterm"
               ];
             };
+
+            # Docker Desktop (Docker.app) が /opt/homebrew 配下へ張る補完シンボリックリンクは
+            # brews の `docker` formula の link ステップと衝突し、`brew bundle` を失敗させる。
+            # Docker Desktop はこの構成の管理外 (casks 未登録) で、docker CLI は brew + Colima に
+            # 一元化する方針のため、bundle 実行前 (extraActivation は homebrew ステップより先に走る) に
+            # Docker.app を指す古い補完シンボリックリンクだけを除去する。
+            # formula 側の補完は brew が改めて配置するため冪等かつ再現可能。
+            system.activationScripts.extraActivation.text = ''
+              for docker_completion in \
+                /opt/homebrew/etc/bash_completion.d/docker \
+                /opt/homebrew/share/fish/vendor_completions.d/docker.fish \
+                /opt/homebrew/share/zsh/site-functions/_docker; do
+                if [ -L "$docker_completion" ] && readlink "$docker_completion" | grep -q '/Applications/Docker.app/'; then
+                  echo "removing stale Docker Desktop completion symlink: $docker_completion" >&2
+                  rm -f "$docker_completion"
+                fi
+              done
+            '';
           }
 
           # Home Manager integration


### PR DESCRIPTION
## 背景

`task apply` (`darwin-rebuild switch`) が Homebrew bundle の段階で失敗し、構成が適用できなくなっていた。

```
Error: The `brew link` step did not complete successfully
Could not symlink etc/bash_completion.d/docker
Target /opt/homebrew/etc/bash_completion.d/docker already exists.
...
Installing docker has failed!
`brew bundle` failed! 1 Brewfile dependency failed to install
[ERROR] ビルド済み darwin-rebuild での構成適用 (.#shunsock-darwin)に失敗しました (exit 1)
```

## 原因

`brews` に含まれる `docker` formula の link ステップが、Docker Desktop (`Docker.app`) が `/opt/homebrew` 配下へ張っていた補完シンボリックリンクと衝突していた。

```
/opt/homebrew/etc/bash_completion.d/docker            -> /Applications/Docker.app/.../docker.bash-completion
/opt/homebrew/share/fish/vendor_completions.d/docker.fish -> /Applications/Docker.app/.../docker.fish-completion
/opt/homebrew/share/zsh/site-functions/_docker        -> /Applications/Docker.app/.../docker.zsh-completion
```

これらの古いリンクが link 先を占有していたため、`docker` formula は Cellar に入るものの link されず (`/opt/homebrew/bin/docker` が生成されない)、bundle 全体が失敗していた。Docker Desktop はこの構成の管理外 (`casks` 未登録) で、docker CLI は brew + Colima に一元化する方針。

## 変更内容

Homebrew bundle より前に走る `system.activationScripts.extraActivation` で、`Docker.app` を指す古い補完シンボリックリンクのみを除去する。

- link 先が `/Applications/Docker.app/` のシンボリックリンクだけを対象にするため安全
- formula 側の補完は brew が改めて配置するため冪等
- fresh install でも同じ経路で衝突を回避でき再現可能

`extraActivation` は nix-darwin の activation 組み立て順で `homebrew` ステップより前に実行されることを、ビルド済み `activate` スクリプトで確認済み。

## 検証

- `task format` / `task validate` (build + check) 成功
- 現マシンでは古いリンク除去後に `brew link docker` が成功し、`docker --version` (29.6.1) を確認
- ビルド済み `activate` スクリプトでクリーンアップが Homebrew bundle より前に配置されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)