### PR TITLE
feat(claude): サブエージェントのモデルを Opus 4.8 に固定

### DIFF
--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -1,5 +1,6 @@
 {
   "env": {
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-8",
     "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
     "BASH_DEFAULT_TIMEOUT_MS": "180000",
     "MAX_THINKING_TOKENS": "10000",


### PR DESCRIPTION
## 概要

Claude Code のサブエージェント（Task 実行）を Opus 4.8 に固定する。メイン会話モデルを Fable 5 等に切り替えても、委譲先のサブエージェントは常に Opus 4.8 で走るようにする。

## 背景

期間限定の Fable 5 を「プランナー」としてメインに据え、実作業は上位モデルのサブエージェントに委譲する運用が注目されている。この運用では「メインは軽量モデル・サブエージェントは高性能モデル」という非対称な構成が要になる。Claude Code は `CLAUDE_CODE_SUBAGENT_MODEL` 環境変数でサブエージェントのモデルを明示的に固定できる。

## 課題

デフォルトではサブエージェントはメイン会話のモデルにフォールバックする。そのためメインを Fable 5 にするとサブエージェントまで Fable 5 になり、実作業の品質を担保できない。サブエージェントのモデルをメインから独立して固定する必要があった。

## 目標

### 必須項目

- サブエージェントを Opus 4.8 に固定し、メインのモデル選択と独立させる
- 設定は `configs/claude/settings.json`（`~/.claude/` の source of truth）に集約する

### 範囲外

- `--append-system-prompt` による「Fable 運用用のシステムプロンプト追記」は扱わない
- メイン会話モデル自体（`ANTHROPIC_MODEL`）の変更は扱わない

## 採用手法

`settings.json` の `env` に `CLAUDE_CODE_SUBAGENT_MODEL` を追加する。値にはエイリアスとフルモデル ID の 2 通りがあり、フル ID `claude-opus-4-8` を採用した。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: フル ID `claude-opus-4-8` | バージョンを正確にピン留めでき再現可能 | 新バージョンへ自動追従しない（手動更新が必要） |
| B: エイリアス `opus` | 常に最新 Opus に追従 | 「最新」の解決先が将来変動し、再現性が損なわれる |

### 採用理由

基本思想の **再現可能性** を優先した。エイリアス `opus` は「最新の Opus」に解決されるため将来のモデル更新で挙動が暗黙に変わる。フル ID なら固定でき、意図しない変動を排除できる。新バージョンへの追従は明示的な設定更新として扱う方が、設定ファイルの宣言性とも整合する。

## 変更箇所

- `configs/claude/settings.json`: `env` に `CLAUDE_CODE_SUBAGENT_MODEL: claude-opus-4-8` を追加

## 妥協と制限

- **自動追従の放棄**: フル ID 固定により、新しい Opus が出ても自動では切り替わらない。バージョン更新は手動で行う。
- **反映にビルドが必要**: `configs/claude/` は `~/.claude/` の source of truth のため、この変更だけでは反映されない。`nix-darwin/` で `task apply`（sudo）が別途必要。

## 検証方法

- 公式ドキュメントで `CLAUDE_CODE_SUBAGENT_MODEL` が公式サポート済みであること、値としてフル ID `claude-opus-4-8` が受け付けられること、モデル解決順位で本変数が最優先であることを確認した。
- `settings.json` が JSON として妥当であること（`env` 内への 1 行追加のみ）を差分で確認した。

## 確認事項

- ⚠️ サブエージェントを Opus 4.8 に **フル ID で固定** する方針で問題ないか（自動追従より再現性を優先）。将来 Opus が更新された際は本設定の手動更新が必要になる。

## 参考文献

- [Claude Code Docs — Sub-agents: Choose a model](https://code.claude.com/docs/en/sub-agents.md#choose-a-model)
- [Claude Code Docs — Model configuration: Environment variables](https://code.claude.com/docs/en/model-config.md#environment-variables)