### PR TITLE
bump: update nix

### DIFF
--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778446047,
-        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
+        "lastModified": 1782772816,
+        "narHash": "sha256-s9BuFv0mRuZx9C1MF8qPHRdcAK14ONi0A5m6E2wqOoM=",
         "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
+        "rev": "5a39d717029e94163ac223aee8d5c9946cafed1c",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775471498,
-        "narHash": "sha256-Y2Z6IOK1p3rugAUKjOyXbgBayzMbZOdmY/87zfKeaKI=",
+        "lastModified": 1783118595,
+        "narHash": "sha256-U70wW3z2LajwIS2wnlO2aJvQdE4BNUGxS8Ytea3/Pb0=",
         "owner": "shunsock",
         "repo": "hisui",
-        "rev": "e4cf64f8770891b1f1fc81814e8f9efc18eee5ee",
+        "rev": "1ca82ab80bc0442db8a5a55a9daf809ed565e1f5",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781411518,
-        "narHash": "sha256-MjswPF7ke1cfT1bUfJir5ELonyOcggcgbOAFOECRih8=",
+        "lastModified": 1783164631,
+        "narHash": "sha256-hKd8rx7mZiTNqTX8MBavh/mACOYP/9GIh3iCbYGO2Do=",
         "owner": "shunsock",
         "repo": "lazynix",
-        "rev": "d57120610328e8ef6d95a5d3b97761c3a27915d8",
+        "rev": "0754f4a0f3cee5da74e597c68211c204de1474ae",
         "type": "github"
       },
       "original": {
@@ -204,11 +204,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1782464540,
-        "narHash": "sha256-xBvJ+sX/7xOoUrjEzglL5B4nH0YgvYTGPIaj9iLeAws=",
+        "lastModified": 1783243767,
+        "narHash": "sha256-iiQL/IHgQlmnZgKgs4wBOiDA9+S3tRFsQPRxtYIhUYo=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "05f2ea6072427bfd8b334342a0816b96fef27c3b",
+        "rev": "22f1080fb54a217bdda6cfd6eca5dbf9e7afddac",
         "type": "github"
       },
       "original": {
@@ -240,11 +240,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782118813,
-        "narHash": "sha256-BnbXO5s5EhV89lLXMAGCzPdEN5a6vNqvMk71obeTEUw=",
+        "lastModified": 1783187857,
+        "narHash": "sha256-CoKGv2FwkvFwzsVLB/N89eFjr40puk/p51IMvIp+ddo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3c092d3c36d91e2f61f3dfb39a159f180a56659",
+        "rev": "19a8a1e6d8b7315b6fd84e5a51977ce6f69d5a5b",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1782959384,
+        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782335603,
-        "narHash": "sha256-sZkQH1CkiZtdvcaLx4sGQD9Q9h+A8qB04DRpqQCN530=",
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "03c72920da828594fae523aaef96f33dff10b340",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要

`nix-darwin/` の flake 依存を `task update` (`nix flake update`) で最新化した。定期的な依存追従の一環で、`nixpkgs` 系および自作/外部 flake input を更新している。

## 背景

nix-darwin のシステム設定は複数の flake input (nixpkgs, nixpkgs-unstable, 自作の hisui / lazynix, 外部の llm-agents) に依存している。これらは上流で継続的に更新されており、放置すると脆弱性修正やバグ修正を取りこぼし、将来のまとめ更新時に差分が肥大化して破壊的変更の切り分けが困難になる。

## 課題

flake.lock が固定されたままだと、上流の改善が反映されず、依存の陳腐化が進む。小さく頻繁に追従することで、各更新の影響範囲を局所化したい。

## 目標

### 必須項目

- `nix-darwin/flake.lock` を最新の input に更新する
- 更新内容を専用ブランチに分離し、レビュー可能な単位でまとめる

### 範囲外

- `task apply` によるシステムへの適用 (sudo が必要なため、マージ後にユーザーが手動実行する)
- flake の input 追加・削除や構成変更 (純粋な lock 更新のみ)

## 採用手法

`task update` (内部で `nix flake update` を実行) により全 input を一括更新した。個別 input の pin ではなく一括更新を選んだのは、input 間の整合性 (特に llm-agents が参照する nixpkgs / flake-parts / bun2nix) を上流の解決結果に委ねるためである。

## 変更箇所

- `nix-darwin/flake.lock`: 以下の input のリビジョンを更新
  - `nixpkgs`: 2026-06-24 → 2026-06-30
  - `nixpkgs-unstable`: 2026-06-26 → 2026-07-02
  - `hisui`: 2026-04-06 → 2026-07-03
  - `lazynix`: 2026-06-14 → 2026-07-04
  - `llm-agents`: 2026-06-26 → 2026-07-05 (推移的に bun2nix / flake-parts / nixpkgs も更新)

## 妥協と制限

- **未適用のまま push**: `task apply` は sudo を伴い Claude では実行できないため、本 PR ではビルド適用を検証していない。実機での動作確認はマージ後のユーザーによる `task apply` に委ねる。

## 検証方法

- `task update` が正常終了し、`nix flake update` が全 input の lock を書き換えたことを確認
- 変更ファイルが `nix-darwin/flake.lock` の 1 ファイルのみであることを `git diff --stat` で確認

## 確認事項

- ⚠️ マージ後、ユーザー環境で `cd nix-darwin && task apply` を手動実行し、更新後の input でシステムが正常にビルド・適用できることを確認する必要がある。

## 参考文献

- [nix flake update](https://nix.dev/manual/nix/latest/command-ref/new-cli/nix3-flake-update)