### PR TITLE
bump: nix-darwin を NixOS 26.05 へアップグレード

### DIFF
--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -158,16 +158,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1783740085,
+        "narHash": "sha256-qajyHfZY29G2oEQk+uHxmsJcRoBUBXP9maTpFlwP/dI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "3cd22efe6471dc7365c822bd9ad73a21e55f38fb",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783690190,
-        "narHash": "sha256-nyxBlf3LLGapHEDrkhIwSBwTA7ih+/zSIi57wMrDR3w=",
+        "lastModified": 1783748509,
+        "narHash": "sha256-LbhKux/T2IgfY8gemtl177v92QpK4Q7XEsCS8ImCMnI=",
         "owner": "shunsock",
         "repo": "lazynix",
-        "rev": "3146e485cae475f56fbcd16814430cab88daa382",
+        "rev": "186caa5d24fb1067b43673bad32eaaaf8bd11960",
         "type": "github"
       },
       "original": {
@@ -224,16 +224,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1772129556,
-        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
+        "lastModified": 1783744694,
+        "narHash": "sha256-2cp6N3rrwnGYLTx9l6N+NI+kwrCWxvJUbj5WJhvB29A=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "rev": "c3e90c89649b07d1a96e4b9dd6cd0d6e44b91a74",
         "type": "github"
       },
       "original": {
         "owner": "LnL7",
-        "ref": "nix-darwin-25.11",
+        "ref": "nix-darwin-26.05",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -272,16 +272,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782847189,
-        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "lastModified": 1783549019,
+        "narHash": "sha256-0XnckG4ZhBmAsYa9mLuEIFowBG0fDGPLHduQGsbMS4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "rev": "74cc63f702f7d60a557e152a57b40fb1fd0f72ac",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778446047,
-        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
+        "lastModified": 1782772816,
+        "narHash": "sha256-s9BuFv0mRuZx9C1MF8qPHRdcAK14ONi0A5m6E2wqOoM=",
         "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
+        "rev": "5a39d717029e94163ac223aee8d5c9946cafed1c",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775471498,
-        "narHash": "sha256-Y2Z6IOK1p3rugAUKjOyXbgBayzMbZOdmY/87zfKeaKI=",
+        "lastModified": 1783530528,
+        "narHash": "sha256-GEEeFcevL2odIb/fxI7NYbeleoB5syO5eUmeckDAHfY=",
         "owner": "shunsock",
         "repo": "hisui",
-        "rev": "e4cf64f8770891b1f1fc81814e8f9efc18eee5ee",
+        "rev": "45b56485968a14bfcb6e0070b7b5b0d4717f7ae0",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781411518,
-        "narHash": "sha256-MjswPF7ke1cfT1bUfJir5ELonyOcggcgbOAFOECRih8=",
+        "lastModified": 1783690190,
+        "narHash": "sha256-nyxBlf3LLGapHEDrkhIwSBwTA7ih+/zSIi57wMrDR3w=",
         "owner": "shunsock",
         "repo": "lazynix",
-        "rev": "d57120610328e8ef6d95a5d3b97761c3a27915d8",
+        "rev": "3146e485cae475f56fbcd16814430cab88daa382",
         "type": "github"
       },
       "original": {
@@ -204,11 +204,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1782464540,
-        "narHash": "sha256-xBvJ+sX/7xOoUrjEzglL5B4nH0YgvYTGPIaj9iLeAws=",
+        "lastModified": 1783738657,
+        "narHash": "sha256-gVS7RTK4lDeHc18V5vhbD6yR+dkj6spiUzlgYS2OP9M=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "05f2ea6072427bfd8b334342a0816b96fef27c3b",
+        "rev": "c69b3057113428150630c05682fa3cfbd312b4d5",
         "type": "github"
       },
       "original": {
@@ -240,11 +240,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782118813,
-        "narHash": "sha256-BnbXO5s5EhV89lLXMAGCzPdEN5a6vNqvMk71obeTEUw=",
+        "lastModified": 1783475452,
+        "narHash": "sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3c092d3c36d91e2f61f3dfb39a159f180a56659",
+        "rev": "05988b07fb05cbcb50be6bce197b4b5f75b5e61b",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {
@@ -272,11 +272,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782335603,
-        "narHash": "sha256-sZkQH1CkiZtdvcaLx4sGQD9Q9h+A8qB04DRpqQCN530=",
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "03c72920da828594fae523aaef96f33dff10b340",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
         "type": "github"
       },
       "original": {

--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -2,18 +2,18 @@
   description = "Flake for macOS";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nix-darwin.url = "github:LnL7/nix-darwin/nix-darwin-25.11";
+    nix-darwin.url = "github:LnL7/nix-darwin/nix-darwin-26.05";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
-    home-manager.url = "github:nix-community/home-manager/release-25.11";
+    home-manager.url = "github:nix-community/home-manager/release-26.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     llm-agents.url = "github:numtide/llm-agents.nix";
-    # lazynix は nixpkgs を nixos-25.11 にピンしており当方と一致するため follows で一本化する。
+    # lazynix 上流の nixpkgs ピンに関わらず、follows で当方の nixpkgs に一本化する。
     lazynix.url = "github:shunsock/lazynix";
     lazynix.inputs.nixpkgs.follows = "nixpkgs";
     # hisui 上流は nixos-25.05 ピンだが、その dotnet SDK は aarch64-darwin で
-    # configureNuget フェーズがクラッシュする。当方の nixos-25.11 に follows させて
+    # configureNuget フェーズがクラッシュする。当方の nixos-26.05 に follows させて
     # 新しい dotnet SDK でビルドする。
     hisui.url = "github:shunsock/hisui";
     hisui.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
## 概要

nix-darwin (macOS 構成) の flake 依存を NixOS **25.11 → 26.05** へアップグレードする。`nixpkgs` / `nix-darwin` / `home-manager` を 26.05 リリースブランチへ更新し、`aarch64-darwin` でのビルド・チェックが通ることを確認済み。

## 背景

定期の flake 更新を起点に、最新の安定リリースである 26.05 系へ追従する。NixOS のリリースは半年ごと (5月 / 11月) に切り替わり、システム構成の 3 本柱 (`nixpkgs` / `nix-darwin` / `home-manager`) は同じリリース系列で揃える必要がある。今回はいずれも `nixos-26.05` / `nix-darwin-26.05` / `release-26.05` ブランチが出揃っているため、まとめて更新した。

`lazynix` / `hisui` は `follows = "nixpkgs"` で当方の nixpkgs に一本化しているため、26.05 に自動追従する。

## 課題

26.05 での検証中、`lazynix` (自作 flake) の Nix ビルドが失敗した。

```
error: couldn't read `crates/lnix-infra/.../templates/lazynix.yaml.template`: No such file or directory
error: could not compile `lnix-infra`
```

原因は nixpkgs 26.05 ではなく **lazynix 側のパッケージングバグ**だった。クレート分割 (`lnix` → `lnix-infra`) でテンプレートが移設されたのに、`lazynix/flake.nix` の crane src フィルタが旧パス `crates/lnix/templates/` を参照し続け、`.template` がビルドサンドボックスから欠落して `include_str!` がコンパイルに失敗していた。

この不具合は上流で先に解消した (下記 参考文献)。本 PR はその修正を含む lazynix を参照する。

## 目標

- 必須: `nixpkgs` / `nix-darwin` / `home-manager` を 26.05 系へ更新する
- 必須: `task validate` (build + check) が `aarch64-darwin` で成功する
- 範囲外: パッケージ構成やモジュールの機能変更 (リリース追従のみに限定)

## 採用手法

| 選択肢 | 内容 | 評価 |
|---|---|---|
| 3 本柱を 26.05 へ揃える (採用) | nixpkgs / nix-darwin / home-manager を同一系列へ | リリース系列の整合が取れ、follows 済みの依存も自動追従 |
| nixpkgs だけ 26.05 | nix-darwin / home-manager は 25.11 のまま | モジュール互換の齟齬リスク。系列を混ぜるのは避ける |
| lazynix を旧版に固定して回避 | ビルドを通すため lazynix を退避 | 最新機能を捨てる後退。上流を直す方が筋が良い |

lazynix の不具合は上流修正 → マージで解消したため、dotfiles 側は lazynix を固定せず最新 (修正済みコミット) を参照する。

## 変更箇所

- `nix-darwin/flake.nix`: `nixpkgs` / `nix-darwin` / `home-manager` の url を 26.05 リリースブランチへ更新。lazynix / hisui の follows コメントの版数記述も追従
- `nix-darwin/flake.lock`: 上記 input と follows 依存の lock を再生成 (lazynix は修正済み最新へ)

## 妥協と制限

- 無し (リリース追従のみ。破壊的なモジュール変更は含まない)

## 検証方法

- `task validate` (nix build `.#shunsock-darwin` + `nix flake check`) が `aarch64-darwin` で成功することを確認
- lazynix の修正は上流 PR の CI (macOS / Ubuntu の Nix ビルド) で緑を確認済み
- `task format` 済み

## 確認事項

- ⚠️ マージ後の適用はユーザーが手動で `cd nix-darwin && task apply` を実行する必要がある (`task apply` は sudo を伴い CI/Claude では実行不可)。25.11 → 26.05 は system 世代が変わるため、apply 時のログを確認されたい

## 参考文献

- 上流修正 (前提): shunsock/lazynix#54 — crane src フィルタのテンプレートパスを lnix-infra に追従

🤖 Generated with [Claude Code](https://claude.com/claude-code)