### PR TITLE
fix: nixfmt-rfc-style を nixfmt へ置き換える

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -74,7 +74,7 @@
       formatter.${system} = pkgs.writeShellApplication {
         name = "nixfmt-tree";
         runtimeInputs = [
-          pkgs.nixfmt-rfc-style
+          pkgs.nixfmt
           pkgs.findutils
         ];
         text = ''

--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -48,7 +48,7 @@
       hurl
       hyperfine
       nerd-fonts.jetbrains-mono
-      nixfmt-rfc-style
+      nixfmt
       rustup
       tree
       wthrr

--- a/nix-os/flake.nix
+++ b/nix-os/flake.nix
@@ -53,7 +53,7 @@
       };
     in
     {
-      formatter.${system} = pkgs.nixfmt-rfc-style;
+      formatter.${system} = pkgs.nixfmt;
 
       nixosConfigurations = {
         myNixOS = nixpkgs.lib.nixosSystem {


### PR DESCRIPTION
## 概要

nixpkgs で deprecated になった `nixfmt-rfc-style` の参照を `nixfmt` に置き換え、`task apply` / `task validate` 時に出る評価警告を解消する。

## 背景

nix-darwin の nixpkgs を 26.05 へ上げた (#354) 後、システム構成を適用すると次の警告が出るようになった。

```
task: [apply] bash script/entry_point/nix/apply.sh
building the system configuration...
evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.
```

nixpkgs 側で RFC 166 スタイルの formatter が正式版となり、`nixfmt-rfc-style` は `nixfmt` への alias に統合された。旧名での参照は今後削除される見込みで、alias 経由の参照に対して警告が出る。

## 課題

このリポジトリには `nixfmt-rfc-style` を参照している箇所が 3 つ残っており、いずれも警告の発生源になっている。警告自体はビルドを壊さないが、apply のたびにノイズとして出力され、本当に注意すべき警告が埋もれる。

## 目標

### 必須項目

- `nixfmt-rfc-style` の参照をリポジトリから無くし、評価警告を出さなくする
- フォーマッタとしての挙動 (`nix fmt` / `task format` の出力) を変えない

### 範囲外

- flake.lock の更新 (今回はパッケージ名の付け替えのみ)
- formatter ラッパー (`nixfmt-tree`) の構造そのものの見直し

## 採用手法

参照名を `nixfmt` に付け替えるだけの最小変更とした。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: `nixfmt` へ参照名を変更 (採用) | 警告が消える。derivation は同一なのでフォーマット結果は不変 | 古い nixpkgs にピンし直すと `nixfmt` が classic 実装を指す可能性がある |
| B: 警告を抑制する設定を入れる | 変更が 1 箇所で済む | 根本原因が残り、alias が削除された時点で壊れる。他の有用な警告も潰しかねない |
| C: 何もしない | 作業ゼロ | apply のたびにノイズが出続け、将来 alias 削除でエラーになる |

### 採用理由

nixpkgs 側が「`nixfmt` を使え」と明示しているため、素直に従うのが最も寿命が長い。B の警告抑制は原因を隠すだけで、alias 削除時にビルドが壊れる。

nix-os は nixpkgs 25.11 ピンで、そこでの `nixfmt` が旧実装 (classic) を指していないかが唯一の懸念だった。実際に評価して確認したところ両者は同一だったため、darwin と揃えて置き換えた。

```
$ nix eval ... '{ rfc = p.nixfmt-rfc-style.name; plain = p.nixfmt.name; }'
{ plain = "nixfmt-1.2.0"; rfc = "nixfmt-1.2.0"; }
```

## 変更箇所

- `nix-darwin/flake.nix`: `nix fmt` ラッパー (`nixfmt-tree`) の runtimeInputs を `pkgs.nixfmt` へ変更
- `nix-darwin/home.nix`: home-manager でインストールするパッケージを `nixfmt` へ変更
- `nix-os/flake.nix`: `formatter` を `pkgs.nixfmt` へ変更

## 妥協と制限

- **nix-os を先回りで変更した**: nix-os (25.11) では現時点で警告は出ていないが、derivation が同一であることを確認した上で darwin と揃えた。将来 25.11 系にピンを戻すような事態がなければ問題にならない。

## 検証方法

- `nix-darwin/` で `task format` — 成功。フォーマット差分は発生しない
- `nix-darwin/` で `task validate` (build + flake check) — 成功し、`evaluation warning` が出力されないことを確認
- `nix eval` で nixpkgs 25.11 / 26.05 の双方において `nixfmt` と `nixfmt-rfc-style` が同一 derivation (nixfmt-1.2.0) であることを確認

## 確認事項

- ⚠️ nix-os (nixpkgs 25.11) 側も同時に置き換えている。NixOS 機では未 apply のため、`task apply` 時に想定外の差分が出ないか確認したい。

## 参考文献

- [#354 bump: NixOS リリースを 26.05 へアップグレード](https://github.com/shunsock/dotfiles/pull/354)