### PR TITLE
chore(claude): メインループとサブエージェントのモデルを Opus 4.6 に変更

### DIFF
--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -1,6 +1,7 @@
 {
+  "model": "claude-opus-4-6",
   "env": {
-    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-8",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-6",
     "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
     "BASH_DEFAULT_TIMEOUT_MS": "180000",
     "MAX_THINKING_TOKENS": "10000",


### PR DESCRIPTION
## 概要

グローバル Claude 設定のソース `configs/claude/settings.json` で、サブエージェント用のモデルを Opus 4.8 から Opus 4.6 へ下げ、併せてメインループ用の `model` キーを新設して同じ Opus 4.6 に揃えた。

## 背景

これまでこのファイルにあったモデル指定は `CLAUDE_CODE_SUBAGENT_MODEL` (Opus 4.8) だけで、メインループのモデルは設定されておらず CLI の既定値に委ねられていた。つまりサブエージェントだけが宣言的に固定され、メインループは環境依存という非対称な状態だった。

## 課題

- サブエージェントを Opus 4.6 に下げても、メインループは既定値のままで揃わない。
- モデルという最も影響の大きい設定が、片方だけ設定ファイルに現れており、実際に何のモデルで動いているかがリポジトリから読み取れない。

## 目標

### 必須項目

- メインループとサブエージェントの双方が Opus 4.6 で動くこと。
- 使用モデルが設定ファイルから一意に読み取れること (環境の既定値に依存しない)。

### 範囲外

- 1M コンテキスト版の明示的な選択。理由は「妥協と制限」に記す。
- `nix-darwin` / `nix-os` での `task apply` による配布反映 (sudo が必要なため本 PR では実施しない)。

## 採用手法

`model` キーを新設し、`env.CLAUDE_CODE_SUBAGENT_MODEL` と同じ値を明示的に置いた。設定値を外部から注入し、環境の既定に依存させないという本リポジトリの方針に沿う。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: `model` を新設し双方 `claude-opus-4-6` | メインループも宣言的に固定でき、使用モデルがファイルから読み取れる | キーが 1 つ増える |
| B: `CLAUDE_CODE_SUBAGENT_MODEL` のみ変更 | 差分が最小 | メインループが既定値のままで、モデルが揃わない。設定の非対称性も残る |
| C: 双方を `claude-opus-4-6[1m]` にする | 1M コンテキストを明示的に選択できる | この ID が実在する根拠が確認できず、無効なら全プロジェクトのモデル設定が壊れる |

### 採用理由

B は今回の要件 (双方を 4.6 に揃える) を満たさない。C は ID の実在を裏取りできなかった (後述)。A が要件を満たしつつ確実に有効な ID のみを使う唯一の案である。

## 変更箇所

- `configs/claude/settings.json`: `model` キーを新設して `claude-opus-4-6` を指定し、`env.CLAUDE_CODE_SUBAGENT_MODEL` を `claude-opus-4-8` から `claude-opus-4-6` に変更した。

## 妥協と制限

- **1M コンテキスト版を明示指定しない**: `claude-opus-4-6[1m]` のようなサフィックス付き ID が Claude Code で有効かどうか、公式ニュースからも二次情報からも確認できなかった。公式ニュースでは Opus 4.6 の 1M は beta かつ Developer Platform 限定・200k 超はプレミアム価格とされており、その後に正式提供・追加料金なしになったとする二次情報がある。いずれもモデル ID 文字列には言及していない。`configs/claude/` はグローバル設定のソースであり、無効な ID の影響が全プロジェクトに及ぶため、確実に有効なサフィックス無しの ID を採用した。

## 検証方法

- `git diff` で意図した 2 行のみの変更であることを確認した。
- JSON の構文が壊れていないことを差分上で確認した。
- 動作確認は `task apply` (sudo 必要) による配布後になるため、本 PR では未実施。

## 確認事項

- ⚠️ メインループを Opus 4.6 に固定する方針でよいか。`model` キーは全プロジェクトの既定モデルを縛るため、影響範囲が最も広い。
- ⚠️ 1M コンテキスト版を明示指定しない判断でよいか。手元の `/model` に Opus 4.6 の 1M 表記が出るなら、その ID に差し替える余地がある。

## 参考文献

- [Claude Opus 4.6 (Anthropic)](https://www.anthropic.com/news/claude-opus-4-6)
- [Claude 1M コンテキストウィンドウが正式提供開始 (Qiita)](https://qiita.com/nogataka/items/f223013206d3ec43ddb8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)