### PR TITLE
chore(claude): メインループとサブエージェントのモデルを Opus 4.7 に変更

### DIFF
--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -1,7 +1,7 @@
 {
-  "model": "claude-opus-4-6",
+  "model": "claude-opus-4-7",
   "env": {
-    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-6",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-7",
     "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
     "BASH_DEFAULT_TIMEOUT_MS": "180000",
     "MAX_THINKING_TOKENS": "10000",


### PR DESCRIPTION
## 概要

グローバル Claude Code 設定のメインループモデルとサブエージェントモデルを、Opus 4.6 から Opus 4.7 に引き上げた。

## 背景

`configs/claude/settings.json` は `~/.claude/settings.json` の single source of truth であり、`model` と `CLAUDE_CODE_SUBAGENT_MODEL` によって全プロジェクトで使うモデルを固定している。直近のコミット (95a9527) で Opus 4.6 に更新したが、その後 Opus 4.7 が利用可能になった。

## 課題

設定が Opus 4.6 に固定されているため、セッションを開くたびに古い世代のモデルが選ばれる。`/model` でセッション単位に切り替えることはできるが、それは一時的で、新規セッションには引き継がれない。恒久的に切り替えるには設定ソース側を変える必要がある。

## 目標

### 必須項目

- メインループのモデルを `claude-opus-4-7` にする
- サブエージェントのモデルを `claude-opus-4-7` にする

### 範囲外

- `~/.claude/` への配布 (`task apply` は sudo が必要なため、ユーザーが手動で実行する)
- エージェント定義 (`configs/claude/agents/`) 側のモデル指定 (現状 `model` frontmatter を持たず、この設定を継承する)

## 採用手法

`settings.json` のモデル ID 文字列を書き換えるだけの最小変更とした。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: `settings.json` の model / CLAUDE_CODE_SUBAGENT_MODEL を書き換える | 設定ソース 1 箇所で全プロジェクト・全サブエージェントに効く。既存の構造を変えない | `task apply` するまで反映されない |
| B: `/model` でセッションごとに切り替える | 即時反映される。リポジトリを変更しない | 新規セッションに引き継がれず、サブエージェントには効かない |

### 採用理由

「恒久的に Opus 4.7 を既定にする」という要求は、宣言的な設定ソースを書き換えることでしか満たせない。B はその場しのぎであり、サブエージェント側のモデルも変えられない。

## 変更箇所

- `configs/claude/settings.json`: `model` と `env.CLAUDE_CODE_SUBAGENT_MODEL` を `claude-opus-4-6` から `claude-opus-4-7` へ変更

## 妥協と制限

- **反映タイミング**: この PR をマージしても `~/.claude/settings.json` は自動更新されない。`nix-darwin/` (または `nix-os/`) で `task apply` を実行して初めて配布される
- **メインループとサブエージェントの一括変更**: 2 つを別々のモデルにする余地は残しているが、今回は従来どおり同一に揃えた

## 検証方法

- 変更後の `settings.json` が JSON として妥当であることを確認 (2 行の文字列置換のみ、構造は不変)
- モデル ID は Anthropic のモデル ID 規約 (`claude-opus-4-8` / `claude-opus-4-7`) に従う

## 確認事項

- ⚠️ サブエージェントも同じく Opus 4.7 に揃える方針でよいか (コスト面でサブエージェントのみ下位モデルに落とす選択肢もある)
