### PR TITLE
feat: docker buildx CLI プラグインを nix-darwin 管理で導入する

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -134,6 +134,7 @@
               brews = [
                 "colima"
                 "docker"
+                "docker-buildx"
                 "docker-compose"
                 "curl"
               ];

--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -64,11 +64,14 @@
       pkgsLlmAgents.antigravity-cli
     ];
 
-  # docker compose (v2 サブコマンド) の CLI プラグイン登録。
-  # Homebrew の docker-compose は単体バイナリを置くのみで `docker compose` から
-  # 認識されないため、~/.docker/cli-plugins/ に brew の opt パスを symlink する。
+  # docker compose / docker buildx (v2 サブコマンド) の CLI プラグイン登録。
+  # Homebrew の docker-compose / docker-buildx は単体バイナリを置くのみで
+  # `docker compose` / `docker build` (buildx バックエンド) から認識されないため、
+  # ~/.docker/cli-plugins/ に brew の opt パスを symlink する。
   # 手動で張ると Docker Desktop 削除時の zap で ~/.docker ごと消えるため、
   # home-manager 管理にして再現性を担保する (opt パスはバージョン非依存)。
   home.file.".docker/cli-plugins/docker-compose".source =
     config.lib.file.mkOutOfStoreSymlink "/opt/homebrew/opt/docker-compose/bin/docker-compose";
+  home.file.".docker/cli-plugins/docker-buildx".source =
+    config.lib.file.mkOutOfStoreSymlink "/opt/homebrew/opt/docker-buildx/bin/docker-buildx";
 }


### PR DESCRIPTION
## 概要

docker client 29 系で `docker build` が legacy builder へフォールバックして DEPRECATED 警告を出す問題に対し、buildx CLI プラグインを nix-darwin (homebrew モジュール) + home-manager 管理で導入する。

## 背景

lapis の `task build:container:application:crawler` 実行時に `DEPRECATED: The legacy builder is deprecated` 警告が出ていた。原因は docker client (brew, colima) に buildx CLI プラグインが無いこと。lapis 側は buildx 明示 + fail-fast に変更済み (shunsock/lapis#20) で、buildx が無いこのホストではビルドがエラー停止するため、環境側の導入が必要になる。

## 課題

brew の `docker-buildx` は単体バイナリを置くだけで、`docker buildx` サブコマンドとして認識されるには `~/.docker/cli-plugins/` への symlink が必要。手動で張ると再現性が失われる (docker-compose のときと同じ課題)。

## 採用手法

既存の docker-compose プラグインとまったく同じパターンを踏襲する:

- `nix-darwin/flake.nix`: `brews` に `docker-buildx` を追加
- `nix-darwin/home.nix`: `home.file.".docker/cli-plugins/docker-buildx"` を `mkOutOfStoreSymlink` で `/opt/homebrew/opt/docker-buildx/bin/docker-buildx` へ symlink (opt パスはバージョン非依存)

既存コメントの主語を docker compose / docker buildx の両方に拡張した以外、構造の変更はない。

## 検証方法

- `task build` (darwin-rebuild build): 成功 — `hm_dockerbuildx.drv` が生成され home-manager が新エントリを認識
- `task check`: all checks passed
- `nixfmt --check`: 差分なし
- lapis 側では nix ビルドの docker-buildx を一時 `DOCKER_CONFIG` に置いた同等構成で、`docker buildx build` によるビルド成功と DEPRECATED 消滅を実機確認済み

## 確認事項

- ⚠️ 適用 (`task apply` = sudo darwin-rebuild switch) はパスワードが必要なため未実施。マージ後に手元での適用が必要

## 参考文献

- [Docker Docs: Build with Docker Buildx](https://docs.docker.com/go/buildx/)
- [shunsock/lapis#20](https://github.com/shunsock/lapis/pull/20)