### PR TITLE
feat: YubiKey Manager (ykman) を home-manager 管理で導入する

### DIFF
--- a/nix-darwin/home.nix
+++ b/nix-darwin/home.nix
@@ -53,6 +53,7 @@
       tree
       wthrr
       yazi
+      yubikey-manager
     ]
     ++ [
       complexity


### PR DESCRIPTION
## 背景

YubiKey を GitHub / Google の 2FA (FIDO2 / WebAuthn) の鍵として導入する。日常の認証はブラウザと macOS 標準の CryptoTokenKit で完結するが、FIDO2 PIN の設定・登録済みクレデンシャルの管理・キーの状態確認には Yubico 公式 CLI の `ykman` が必要になる。

事前調査で、nixpkgs (nixos-26.05) の `yubikey-manager` (5.9.1) が aarch64-darwin をサポートしており、本リポジトリの制約 (パッケージ導入は Nix 経由のみ) の範囲で導入できることを確認した。詳細は Issue #371 を参照。

## 変更内容

`nix-darwin/home.nix` の `home.packages` (stable `pkgs` 側リスト) に `yubikey-manager` を 1 行追加した。リストの並びに合わせて `yazi` の直後に置いている。

macOS は CryptoTokenKit と PCSC.framework を標準提供するため、Linux で必要な `pcscd` 相当のデーモン設定 (nix-darwin モジュール) は不要で、パッケージ追加のみで完結する。

## 意思決定

- **stable (5.9.1) を採用**: unstable は 5.9.2 だが差分はマイナーで、unstable 依存を増やす理由がない
- **GUI は導入しない**: 旧 `yubikey-manager-qt` は 2025-06-07 に nixpkgs から削除済み。後継の `yubioath-flutter` は nixpkgs では Linux 限定のため、macOS では CLI 運用とする
- **関連パッケージはスコープ外**: `age-plugin-yubikey` / `yubikey-agent` などは 2FA 用途に不要のため、必要になった時点で別途追加する

## 検証

- `task format` — 成功
- `task validate` — build (`python3.13-yubikey-manager-5.9.1` を含む) / flake check ともに成功

マージ後はユーザーによる `task apply` (sudo) が必要。初回の `ykman` 実行時は、実行するターミナルアプリ (WezTerm など) への Input Monitoring 権限の許可を macOS が要求する点に注意。

## 確認事項

- `home.nix` の既存コメント (`# ユーザー情報` など) がコメント規約の whitelist マーカーに従っていない指摘が hook から出ているが、本 PR のスコープ外として触れていない。必要なら別 PR で対応する

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
