### PR TITLE
fix: require_tasks hook が Task ツール非対応セッションで Write/Edit を恒久ブロックする

### DIFF
--- a/configs/claude/hooks/README.md
+++ b/configs/claude/hooks/README.md
@@ -27,12 +27,25 @@ SEE: https://code.claude.com/docs/en/hooks#posttooluse-decision-control
 |---|---|---|
 | `validate_bash.cs` | PreToolUse (Bash) | 禁止コマンドを拒否し代替を案内する |
 | `pr_submission_via_skill.cs` | PreToolUse (Bash) | `gh pr create` の直接実行を拒否し submit__pull_request へ誘導する |
-| `require_tasks.cs` | PreToolUse (Write\|Edit) | in_progress な Task が無い状態の編集を deny でブロックする |
+| `require_tasks.cs` | PreToolUse (Write\|Edit) | in_progress な Task が無い状態の編集を deny でブロックする (plans/ と scratchpad は除外) |
 | `trigger_ci_fix.cs` | PostToolUse (Bash) | `git push` / `gh pr create` 成功後に monitor__ci_status を促す |
 | `write_structured_comment.cs` | PostToolUse (Write\|Edit) | ソース編集後に write__structured_comment を促す |
 | `clean_comment_out.cs` | PostToolUse (Write\|Edit) | ソース編集後に clean__comment_out を促す |
 | `validate_comment_format.cs` | PostToolUse (Write\|Edit) | コメントを走査し語彙・2行・80文字・issue番号の違反を検出して修正を促す |
 | `block_stop_on_open_tasks.cs` | Stop | 未完了 Task が残ったままの停止をブロックする |
+
+## Task 必須フック (require_tasks.cs)
+
+`$HOME/.claude/tasks/<session_id>/*.json` を走査し in_progress な Task が 1 つも
+無い状態の Write/Edit を deny でブロックする。判定対象外は次の 2 つ:
+
+- `/.claude/plans/` を含むパス — 計画メモは作業単位を持たない
+- `/private/tmp/claude-` から始まるパス — scratchpad は作業単位を持たない
+
+TaskCreate/TaskUpdate ツールが利用できないハーネスでも編集を再開できるよう、deny
+メッセージ (`permissionDecisionReason`) に task json を直接作成する `mkdir` + `printf`
+の実行例を埋め込んでいる。session_id は hook が stdin ペイロードから取得しメッセージに
+差し込むため、そのままコピーして実行すれば in_progress な Task を宣言できる。
 
 ## コメント整理フック (writer → cleaner → validator)
 

--- a/configs/claude/hooks/require_tasks.cs
+++ b/configs/claude/hooks/require_tasks.cs
@@ -71,11 +71,14 @@ internal static class Program
             && SessionIdPattern.IsMatch(sessionId)
             && !IsExemptPath(filePath)
             && !Tasks.HasInProgress(sessionId);
-        if (!mustDeny) return 0;
+        if (!mustDeny)
+            return 0;
 
         // CONSTRAINT: deny は JSON 出力でのみ有効 (終了コードではブロック不可)。
         // SEE: https://code.claude.com/docs/en/hooks
-        var decision = new Decision(new HookSpecificOutput("PreToolUse", "deny", BuildReason(sessionId)));
+        var decision = new Decision(
+            new HookSpecificOutput("PreToolUse", "deny", BuildReason(sessionId))
+        );
         Console.WriteLine(JsonSerializer.Serialize(decision, HookJson.Default.Decision));
         return 0;
     }
@@ -99,8 +102,7 @@ internal static class Program
     private static bool IsExemptPath(string filePath) =>
         filePath.Length > 0
         && Path.GetFullPath(filePath) is string full
-        && (full.Contains("/.claude/plans/")
-            || full.StartsWith("/private/tmp/claude-"));
+        && (full.Contains("/.claude/plans/") || full.StartsWith("/private/tmp/claude-"));
 }
 
 record HookInput(

--- a/configs/claude/hooks/require_tasks.cs
+++ b/configs/claude/hooks/require_tasks.cs
@@ -1,4 +1,4 @@
-// require_tasks.cs - PreToolUse hook for Claude Code (.NET file-based app, Write|Edit)
+// require_tasks.cs - PreToolUse hook for Claude Code (Write|Edit)
 //
 // in_progress な Task が 1 つも無い状態での Write/Edit を deny でブロックする。
 // 「編集を始める前に、その作業を担う Task を in_progress にする」規約を強制する
@@ -11,88 +11,97 @@
 // 実機検証の結果、アクティブセッション中は TaskCreate/TaskUpdate が同 json を同期で
 // 生成・更新するため、編集の瞬間の「現在 in_progress な Task」をディスクから確実に
 // 判定できる。session_id を得る環境変数は無いため、stdin ペイロードが唯一の取得元。
-// see: https://code.claude.com/docs/en/hooks#pretooluse-decision-control
+// SEE: https://code.claude.com/docs/en/hooks#pretooluse-decision-control
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 
 internal static class Tasks
 {
-    // session のタスク json を走査し、in_progress な Task が 1 つでもあれば true。
-    // ディレクトリが無い / 読めない json は安全側に無視する。
+    // CONSTRAINT: ディレクトリ欠落・不正 json は安全側に無視し false を返す。
     public static bool HasInProgress(string sessionId)
     {
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var dir = Path.Combine(home, ".claude", "tasks", sessionId);
-        if (!Directory.Exists(dir))
-            return false;
-
-        foreach (var path in Directory.EnumerateFiles(dir, "*.json"))
-        {
-            if (ReadStatus(path) == "in_progress")
-                return true;
-        }
-
-        return false;
+        return Directory.Exists(dir)
+            && Directory.EnumerateFiles(dir, "*.json").Any(IsInProgress);
     }
 
-    private static string? ReadStatus(string path)
+    private static bool IsInProgress(string path)
     {
         try
         {
-            var task = JsonSerializer.Deserialize(
-                File.ReadAllText(path),
-                TaskJson.Default.TaskState
-            );
-            return task?.Status;
+            var t = JsonSerializer.Deserialize(File.ReadAllText(path), TaskJson.Default.TaskState);
+            return t?.Status == "in_progress";
         }
         catch
         {
-            return null;
+            return false;
         }
     }
 }
 
 internal static class Program
 {
-    private const string Reason =
+    // CONSTRAINT: "." / ".." は tasks/../ 外を指すため負の先読みで除外する。
+    private static readonly Regex SessionIdPattern = new(@"^(?!\.+$)[A-Za-z0-9._-]+$");
+
+    // CONSTRAINT: 手動で task json を作る fallback コマンドを reason に埋め込む。
+    private static string BuildReason(string sessionId) =>
         "in_progress な Task が無い状態での Write/Edit は禁止されている。\n\n"
         + "ファイルを編集する前に、その編集を担う Task を必ず in_progress にしなければならない。"
         + "in_progress な Task が 1 つも無いままの編集は規約違反であり、この編集はブロックされた。\n\n"
         + "1. まだ Task が無ければ TaskCreate で作業を分解する\n"
         + "2. これから着手するステップの Task を TaskUpdate で in_progress にする\n"
         + "3. そのステップが完了したら completed にする\n\n"
-        + "いま該当 Task を in_progress にしてから、編集をやり直すこと。";
+        + "いま該当 Task を in_progress にしてから、編集をやり直すこと。\n\n"
+        + "TaskCreate/TaskUpdate ツールがこのセッションで利用不可の場合は、"
+        + "作業単位を宣言する task json を直接作成してから編集をやり直すこと。実行例:\n"
+        + $"mkdir -p ~/.claude/tasks/{sessionId} && "
+        + "printf '{\"status\":\"in_progress\",\"subject\":\"<作業内容>\"}' "
+        + $"> ~/.claude/tasks/{sessionId}/manual-1.json";
 
     private static async Task<int> Main()
     {
-        var input = await Console.In.ReadToEndAsync();
-        var hook = JsonSerializer.Deserialize(input, HookJson.Default.HookInput);
-        if (hook?.ToolName is not ("Write" or "Edit"))
-            return 0;
+        HookInput? hook = TryParse(await Console.In.ReadToEndAsync());
+        var sessionId = hook?.SessionId ?? "";
+        var filePath = hook?.ToolInput?.FilePath ?? "";
+        var mustDeny =
+            hook?.ToolName is "Write" or "Edit"
+            && SessionIdPattern.IsMatch(sessionId)
+            && !IsExemptPath(filePath)
+            && !Tasks.HasInProgress(sessionId);
+        if (!mustDeny) return 0;
 
-        // session_id が取れない場合は、別セッションやサブエージェントの状態で
-        // 誤ってブロックしないよう、安全側に倒して許可する。
-        var sessionId = hook.SessionId ?? "";
-        if (sessionId.Length == 0)
-            return 0;
-
-        // 計画立案そのものは止めない。plan ファイルの作成は編集前の安全なステップで
-        // あり、Task の存在を要求すると plan モードが自身の plan を書けなくなる。
-        var filePath = hook.ToolInput?.FilePath ?? "";
-        if (filePath.Contains("/.claude/plans/"))
-            return 0;
-
-        if (Tasks.HasInProgress(sessionId))
-            return 0;
-
-        // 終了コードでは確実にブロックできない (exit 1 等は非ブロッキング扱い)。
-        // PreToolUse は permissionDecision: "deny" の JSON 出力でのみツール実行を拒否する。
-        // see: https://code.claude.com/docs/en/hooks
-        var decision = new Decision(new HookSpecificOutput("PreToolUse", "deny", Reason));
+        // CONSTRAINT: deny は JSON 出力でのみ有効 (終了コードではブロック不可)。
+        // SEE: https://code.claude.com/docs/en/hooks
+        var decision = new Decision(new HookSpecificOutput("PreToolUse", "deny", BuildReason(sessionId)));
         Console.WriteLine(JsonSerializer.Serialize(decision, HookJson.Default.Decision));
         return 0;
     }
+
+    // CONSTRAINT: 不正 JSON・空 stdin では未捕捉例外で落ちるため null を返す。
+    private static HookInput? TryParse(string input)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize(input, HookJson.Default.HookInput);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    // CONSTRAINT: plans/ と scratchpad は作業単位を持たないため対象外。
+    // CONSTRAINT: traversal を弾くため正規化後のパスで判定する。
+    // CONSTRAINT: Path.GetFullPath("") は例外になるため長さで先に弾く。
+    private static bool IsExemptPath(string filePath) =>
+        filePath.Length > 0
+        && Path.GetFullPath(filePath) is string full
+        && (full.Contains("/.claude/plans/")
+            || full.StartsWith("/private/tmp/claude-"));
 }
 
 record HookInput(

--- a/configs/claude/hooks/require_tasks.cs
+++ b/configs/claude/hooks/require_tasks.cs
@@ -24,8 +24,7 @@ internal static class Tasks
     {
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var dir = Path.Combine(home, ".claude", "tasks", sessionId);
-        return Directory.Exists(dir)
-            && Directory.EnumerateFiles(dir, "*.json").Any(IsInProgress);
+        return Directory.Exists(dir) && Directory.EnumerateFiles(dir, "*.json").Any(IsInProgress);
     }
 
     private static bool IsInProgress(string path)


### PR DESCRIPTION
## 概要

PreToolUse hook `require_tasks.cs` が TaskCreate/TaskUpdate ツールを持たないセッションで Write/Edit を恒久ブロックする問題を解消する。deny メッセージに手動フォールバック手順を埋め込み、scratchpad を判定対象外にした。

Closes #374

## 背景

2026-07-21 のセッション (claude-fable-5、Task ツール非提供のハーネス構成) で、scratchpad への Markdown 書き出しが本 hook に deny された。deny メッセージは TaskCreate → TaskUpdate の手順を指示するが、当該セッションにはそのツールが存在せず、指示に従うことが不可能だった。エージェントは Bash ヒアドキュメントで書き出しを代替せざるを得ず、ハードゲートだけでなく `Write|Edit` matcher の品質ゲート群 (コメント整理フック等) まで素通りする誘因になっていた。

## 課題

- hook の判定は `~/.claude/tasks/<session_id>/*.json` の `status: "in_progress"` の有無のみで、その json を作れるのは Task ツールだけという前提だった。前提が崩れたときの脱出経路が無い
- 除外は `/.claude/plans/` のみで、作業単位を持たない scratchpad への一時ファイルまでブロックされる

## 目標

### 必須項目

- Task ツールが無いセッションでも、deny メッセージ記載の手順のみで Write/Edit を再開できる
- `/private/tmp/claude-` 配下への Write/Edit を in_progress Task 無しで許可する
- in_progress Task が無い状態でのプロジェクトファイル編集は引き続き deny する (非退行)

### 範囲外

- `block_stop_on_open_tasks.cs` (Stop hook) の変更 — Task が 1 つも無いセッションでは発火せず実害がないため (issue の補足参照)
- `~/.claude/hooks/` への反映 (`task apply`) — sudo が必要なため本 PR ではソース更新まで

## 採用手法

hook の判定はディスク上の task json を読むだけなので、宣言の手段をツールに限定する必要はない。deny メッセージへ「task json を直接作成する」手動フォールバックのコマンド例 (実 session_id 入り) を埋め込むことで、判定ロジックのハードゲート性を保ったまま全ハーネスで脱出可能にした。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: deny メッセージに手動フォールバックを明記 + scratchpad 除外 (採用) | ゲートの意図 (編集前の作業宣言) を保ちつつ全ハーネスで脱出可能 | 手動 json は Task ツール由来よりスキーマが薄い |
| B: tasks ディレクトリ不在時は fail-open | 実装が最小 | 初回 TaskCreate 前は常にディレクトリ不在のため、ゲートが骨抜きになる |
| C: hook がツール一覧を検査して Task ツール不在なら許可 | 誤爆が原理的に無い | PreToolUse の stdin ペイロードにセッションのツール一覧が無く実現不能 |

### 採用理由

案 A は「編集前に作業単位を in_progress として宣言する」というゲートの意図を変えずに、宣言の手段だけを広げる。session_id は hook が stdin から取得済みのため、エージェントが自力で知り得ない値をメッセージ側で補完できる。

実装過程のレビュー (境界値・敵対的入力のスモーク) で見つかった堅牢性の穴も同時に塞いだ:

- 除外判定を `Path.GetFullPath` で正規化し、`/private/tmp/claude-x/../../../...` のような traversal でゲートを迂回できないようにした
- session_id を `^(?!\.+$)[A-Za-z0-9._-]+$` で検証し、`..` や shell 的に危険な文字列がディレクトリ探索・メッセージ埋め込みに使われないようにした
- 不正 JSON / 空 stdin での未捕捉例外 (exit 134) を解消し、明示的に安全側 (許可) へ倒した

## 変更箇所

- `configs/claude/hooks/require_tasks.cs`: `Reason` 定数を `BuildReason(sessionId)` に変更し手動フォールバック手順を埋め込み。scratchpad 除外・パス正規化・session_id 検証・stdin パースの安全化を追加
- `configs/claude/hooks/README.md`: 手動フォールバックの存在と判定対象外 (plans / scratchpad) を記載

## 妥協と制限

- **NUL 文字入り file_path での異常終了**: `Path.GetFullPath` が ArgumentException を投げ exit 134 (fail-open) になる経路が残る。実際の Write/Edit ツールが NUL 入りパスを渡すことは現実的に無く、レビュー反復上限 (3 回) に達したため既知の制限として残した
- **`is string full` の束縛イディオム** (`IsExemptPath`): 認知的複雑度ゲート (ベースライン 9.65 以下) を満たすため式本体を維持した。常に成立するパターンマッチを let 束縛に使う点は可読性レビューで low 指摘が残っている
- **手動 json のスキーマの薄さ**: `subject` と `status` のみで、Task ツールが生成する json より情報が少ない (issue の採用案どおり)

## 検証方法

- `dotnet run` によるスモークテスト 13 ケース全通過 (HOME 差し替えで隔離実行): deny メッセージへの session_id 埋め込み / 手動 json での再開 / scratchpad 許可 / plans 許可 / traversal 拒否 / 不正 JSON・空 stdin の安全化 / 敵対的 session_id の拒否 / `report..md` 等の正当名の許可
- 認知的複雑度 (thoughtbot/complexity): 9.648524 (main) → 9.244798 (改善)
- レビュー 3 反復 (readability / consistency / bug_checker / complexity / comment 品質) を実施し、mid 以上の指摘は全件解消

## 確認事項

- ⚠️ 手動フォールバックの開放度: deny メッセージが「task json を直接作れ」と案内するため、Task ツールがあるセッションのエージェントもこの経路を選べてしまう。ゲートの意図 (作業単位の宣言) 自体は手動 json でも満たされるという整理でよいか
- ⚠️ scratchpad 除外の prefix は `/private/tmp/claude-` (macOS の実パス表記)。`/tmp/claude-` 表記は対象外のままでよいか (issue 採用案どおり)

## 参考文献

- [Issue #374](https://github.com/shunsock/dotfiles/issues/374)
- [Claude Code hooks — PreToolUse decision control](https://code.claude.com/docs/en/hooks#pretooluse-decision-control)
- [発生セッションの作業 (shunsock/lapis#49)](https://github.com/shunsock/lapis/issues/49)
