### PR TITLE
feat(claude): keybindings.json を追加し claude agents の board 画面を Vim 風に操作できるようにする

### DIFF
--- a/configs/claude/keybindings.json
+++ b/configs/claude/keybindings.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-keybindings.json",
+  "$docs": "https://code.claude.com/docs/ja/keybindings",
+  "bindings": [
+    {
+      "context": "Select",
+      "bindings": {
+        "shift+j": "select:next",
+        "shift+k": "select:previous"
+      }
+    }
+  ]
+}

--- a/nix-darwin/module/claude.nix
+++ b/nix-darwin/module/claude.nix
@@ -24,6 +24,11 @@
     run install -Dm644 ${../../configs/claude/settings.json} $HOME/.claude/settings.json
   '';
 
+  # CONSTRAINT: keybindings.json は /keybindings コマンドが実行時に書き込むため symlink 不可
+  home.activation.claudeKeybindings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    run install -Dm644 ${../../configs/claude/keybindings.json} $HOME/.claude/keybindings.json
+  '';
+
   home.activation.claudeStatusline = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     run install -Dm755 ${../../configs/claude/statusline.sh} $HOME/.claude/statusline.sh
   '';

--- a/nix-os/modules/claude.nix
+++ b/nix-os/modules/claude.nix
@@ -19,6 +19,11 @@
     run install -Dm644 ${../../configs/claude/settings.json} $HOME/.claude/settings.json
   '';
 
+  # CONSTRAINT: keybindings.json は /keybindings コマンドが実行時に書き込むため symlink 不可
+  home.activation.claudeKeybindings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    run install -Dm644 ${../../configs/claude/keybindings.json} $HOME/.claude/keybindings.json
+  '';
+
   home.activation.claudeHooks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     run mkdir -p $HOME/.claude/hooks
     run install -Dm644 ${../../configs/claude/hooks/validate_bash.cs} $HOME/.claude/hooks/validate_bash.cs


### PR DESCRIPTION
## 概要

Claude Code のカスタムキーバインディング設定 `configs/claude/keybindings.json` を新規追加し、`claude agents` の board 画面のようなリスト UI (`Select` コンテキスト) で Shift+J / Shift+K を ↓ / ↑ と同じ移動に割り当てる。設定は nix-darwin / nix-os 両方の home-manager モジュールから `~/.claude/keybindings.json` へ配布する。

Closes #375

## 背景

日常的に Nvim と併用しているため、`claude agents` の board 画面 (実行中ジョブの一覧) もホームポジションから離れず操作したい。Claude Code は `~/.claude/keybindings.json` によるキーバインディングのカスタマイズを公式にサポートしているが、このリポジトリの Claude 設定ソース (`configs/claude/`) にはまだ存在せず、dotfiles の管理外だった。

## 課題

- board 画面のジョブ一覧で Shift+J / Shift+K が反応せず、矢印キーに手を伸ばす必要があった
- キーバインディングが dotfiles 管理外のため、環境を再構築するとカスタマイズが失われる

## 目標

### 必須項目

- `Select` コンテキストで `shift+j` → `select:next`、`shift+k` → `select:previous` が定義された `keybindings.json` を `configs/claude/` に置く
- nix-darwin / nix-os の両モジュールが同ファイルを `~/.claude/keybindings.json` へ配布する (parity 維持)

### 範囲外

- 入力欄の Vim mode 化 — `"editorMode": "vim"` は `configs/claude/settings.json` に設定済みのため変更不要 (実機確認のみ)
- board 画面での実機検証 — `task apply` (sudo) が必要なためマージ後にユーザーが実施する

## 採用手法

board 画面のような汎用リスト UI は公式ドキュメント上 `Select` コンテキストに属し、`select:next` / `select:previous` のデフォルト (Down・j / Up・k など) に Shift+J / Shift+K を追加バインドする。配布は既存の `claudeSettings` と同じ「install による書き込み可能なコピー」パターンを踏襲する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: `Select` コンテキストに追加バインド + `install -Dm644` で配布 (採用) | 全リスト UI で一貫した Vim 風操作。既存 j/k・矢印キーと共存。`/keybindings` での実行時編集が可能 | board 画面が `Select` に属することはドキュメントに明記がなく実機検証が必要 |
| B: `Global` コンテキストにバインド | 全画面で効く | `select:*` アクションは `Select` 専用で `Global` から動く保証がない。チャット入力との衝突リスク |
| C: `home.file` symlink で配布 | 宣言的で activation 不要 | Nix store への symlink は読み取り専用となり `/keybindings` コマンドの実行時編集が失敗する |

### 採用理由

`settings.json` で確立済みの「実行時に書き込まれるファイルは symlink 不可」という制約 (既存の CONSTRAINT コメント) が keybindings.json にもそのまま当てはまるため、同一パターンの踏襲が最も予測可能で保守しやすい。

## 変更箇所

- `configs/claude/keybindings.json`: 新規。`Select` コンテキストに `shift+j` / `shift+k` を定義 (公式 JSON Schema 準拠)
- `nix-darwin/module/claude.nix`: `claudeKeybindings` activation を追加し `~/.claude/keybindings.json` へ配布
- `nix-os/modules/claude.nix`: 同上 (nix-darwin と同一パターン)

## 妥協と制限

- **`task apply` 再実行で実行時編集が消える**: `/keybindings` コマンドで加えた変更は次回 activation で宣言的ソースに上書きされる。`settings.json` と同一の設計であり、dotfiles を single source of truth とする方針を優先した
- **NixOS 側はビルド未検証**: toplevel ビルドは x86_64-linux 専用のため、macOS 上では構文検証 (`nix-instantiate --parse`) と nix-darwin 側との構造一致確認まで

## 検証方法

- jq による構造アサーション 7 件 (valid JSON・`Select` コンテキスト・両バインド・`$schema` / `$docs`)
- schemastore の公式 JSON Schema で検証 (`check-jsonschema` → ok)
- `nix-instantiate --parse` を両モジュールで実行 (構文 OK)、nixfmt --check pass (追加行)
- nix-darwin のビルド (`build.sh`) 成功
- GNU `install -Dm644` の分離検証: 親ディレクトリ作成・非 symlink・mode 644・冪等性・実行時編集の上書き復元
- 認知的複雑度: 増分は宣言 5 行の長さ起因のみで行あたり複雑度は非悪化 (darwin 5.62→6.38 / nixos 4.17→4.92)

## 確認事項

- ⚠️ board 画面が `Select` コンテキストに属する前提はドキュメントに明記がない。マージ後 `task apply` して `claude agents` で Shift+J / Shift+K の動作確認をお願いしたい (効かない場合は `claude --debug` でコンテキストを特定して Issue に追記)
- ⚠️ 実行時編集が activation で上書きされる設計 (settings.json と同じ) の受け入れ可否

## 参考文献

- [Issue #375](https://github.com/shunsock/dotfiles/issues/375)
- [キーボードショートカットのカスタマイズ — Claude Code Docs](https://code.claude.com/docs/ja/keybindings)
- [インタラクティブモード (Vim mode) — Claude Code Docs](https://code.claude.com/docs/ja/interactive-mode)
