### PR TITLE
feat(claude): Alt+hjkl で vim ライクな UI ナビゲーションを keybindings.json に導入

### DIFF
--- a/configs/claude/keybindings.json
+++ b/configs/claude/keybindings.json
@@ -3,10 +3,65 @@
   "$docs": "https://code.claude.com/docs/ja/keybindings",
   "bindings": [
     {
-      "context": "Select",
+      "context": "Global",
       "bindings": {
-        "shift+j": "select:next",
-        "shift+k": "select:previous"
+        "alt+j": "select:next",
+        "alt+k": "select:previous"
+      }
+    },
+    {
+      "context": "Confirmation",
+      "bindings": {
+        "alt+j": "confirm:next",
+        "alt+k": "confirm:previous",
+        "alt+h": "confirm:previousField",
+        "alt+l": "confirm:nextField"
+      }
+    },
+    {
+      "context": "MessageSelector",
+      "bindings": {
+        "alt+j": "messageSelector:down",
+        "alt+k": "messageSelector:up"
+      }
+    },
+    {
+      "context": "DiffDialog",
+      "bindings": {
+        "alt+j": "diff:nextFile",
+        "alt+k": "diff:previousFile",
+        "alt+h": "diff:previousSource",
+        "alt+l": "diff:nextSource"
+      }
+    },
+    {
+      "context": "ModelPicker",
+      "bindings": {
+        "alt+h": "modelPicker:decreaseEffort",
+        "alt+l": "modelPicker:increaseEffort"
+      }
+    },
+    {
+      "context": "Tabs",
+      "bindings": {
+        "alt+h": "tabs:previous",
+        "alt+l": "tabs:next"
+      }
+    },
+    {
+      "context": "Attachments",
+      "bindings": {
+        "alt+h": "attachments:previous",
+        "alt+l": "attachments:next"
+      }
+    },
+    {
+      "context": "Footer",
+      "bindings": {
+        "alt+j": "footer:down",
+        "alt+k": "footer:up",
+        "alt+h": "footer:previous",
+        "alt+l": "footer:next"
       }
     }
   ]


### PR DESCRIPTION
## 概要

Claude Code のリスト・ピッカー UI を hjkl で操作できるよう `keybindings.json` を書き換えた。修飾子は Shift から Alt (= Meta = Option) へ変更し、8 つの context に上下左右 action を割り当てた。

## 背景

前回 PR (#377) で `Select` context に Shift+J / Shift+K を割り当てて vim ライクな上下移動を導入したが、実際に触るとほとんどのシーンで動かなかった。

- Chat 入力欄では Shift+J / K は単に大文字の `J` / `K` として送信される
- `/keybindings` を試そうにも agent view (FleetView) では「isn't available in agent view」と拒否される
- `Select` context 自体は極めて狭い範囲 (raw な select/list component focus 時) しかカバーせず、ModelPicker / MessageSelector / Confirmation 等は独自 context を持つ

## 課題

- Shift 修飾子は文字入力と衝突するため、キー入力欄では bind を張っても素通りする
- Cmd (⌘) は macOS の terminal がアプリまで通さず (システムショートカット / terminal メニュー横取り)、ドキュメントも "alt and meta are identical in terminals" と明記し Cmd 単独の扱いは実質サポート外
- Claude Code の keybinding は「キー → 別のキー」変換をサポートせず、`select:next` のような action にしか bind できないため、hjkl を「矢印キー相当」にするには各 context の左右/上下 action を列挙する必要がある

## 目標

### 必須項目

- terminal で確実にアプリまで届く修飾子で hjkl を bind し、Chat 入力欄で文字化けしないこと
- リストが登場する主要 UI (Confirmation, MessageSelector, DiffDialog, ModelPicker, Tabs, Attachments, Footer) で hjkl による移動が可能になること
- Global に汎用的な上下 (`select:next` / `select:previous`) を持たせ、context-specific bind が無い場面でも j / k が効くこと

### 範囲外

- agent view (FleetView) の bind — 公開 context に含まれておらず Claude Code 側の実装が必要
- Chat context 内でのカーソル移動 — 文字入力が本質的な context なので触らない
- `~/.claude/keybindings.json` への配布 — `nix-darwin/` 側の `task apply` はユーザー実行 (Claude では sudo 不可)

## 採用手法

修飾子として **Alt** を採用した。docs (`configs/claude/skills/keybindings-help`) の Modifiers 節に "alt and meta are identical in terminals" とあり、terminal 経由では `alt+X` = `meta+X` = `opt+X` として ESC+X の escape sequence で届く。Cmd は届かないため候補から外す。Ctrl は既定バインド (`ctrl+j`=chat:newline, `ctrl+l`=chat:clearInput, `ctrl+h`=backspace 等) と衝突が激しく現実的でない。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: Alt+hjkl を各 context に個別 bind (採用) | terminal を確実に通る / 既定と衝突しない / hjkl の意味づけを context ごとに最適化できる | context ごとに action を列挙する必要があり verbose |
| B: Cmd+hjkl | 見た目が macOS っぽい | terminal でアプリまで届かない (実質不可) |
| C: Shift+hjkl (前回案) | 修飾子が単純 | Chat 等の入力欄で大文字入力になり素通り |
| D: Ctrl+hjkl | terminal を通る | `ctrl+j`=newline, `ctrl+l`=clearInput 等の既定と衝突 |
| E: Global のみ 4 個 bind して済ませる | JSON が短い | `select:*` action が Chat / MessageSelector 等では発火せず、実効カバー範囲が狭い |

### 採用理由

- Alt は terminal をエスケープシーケンスとして通り、Chat 入力欄でも文字入力にならない
- 選択肢 A の verbose さは JSON 60 行程度に収まり許容範囲
- 各 context で意味的に自然な action (例: DiffDialog では h/l が source 切替、j/k が file 切替) にマップできる

## 変更箇所

- `configs/claude/keybindings.json`: 前回導入した `Select` + Shift+J/K を除去し、Global (select:next/previous) と Confirmation / MessageSelector / DiffDialog / ModelPicker / Tabs / Attachments / Footer の各 context に Alt+hjkl を再割り当て

## 妥協と制限

- **agent view で効かない**: FleetView は公開 context 一覧に無く、そもそも keybindings.json でカスタマイズできない。Claude Code 側の対応待ち
- **verbose な列挙**: Claude Code に「キー → キー」変換や汎用的な `directional:left/right` action が無いため、context ごとに個別 bind するしかない。将来抽象化される余地はある
- **Chat / Autocomplete / Help 等はスコープ外**: Chat は文字入力が本質、Autocomplete は既定の up/down で十分と判断し、今回は触らない

## 検証方法

- ローカルで `configs/claude/keybindings.json` を編集後、JSON 構造が docs の期待するスキーマ (`{ bindings: [{ context, bindings: {key: action} }] }`) と一致していることを確認
- `~/.claude/keybindings.json` への配布は `nix-darwin/` で `task apply` した後、Claude Code を再起動してから以下を手動で試す (レビュー時にお願いします):
  - Confirmation ダイアログで Alt+j / Alt+k で選択肢移動、Alt+h / Alt+l で field 移動
  - モデルピッカー (Meta+P) で Alt+h / Alt+l で effort レベル変更
  - Message selector (rewind) で Alt+j / Alt+k で上下移動

## 確認事項

- ⚠️ Alt+hjkl の割り当てが各 context の既定キー (up/down/left/right) の追加であることを確認 (既定を潰していない)
- ⚠️ Footer で `alt+j` → `footer:down`, `alt+k` → `footer:up` としているが、Footer には `footer:up` / `footer:down` の他に `footer:previous` / `footer:next` (左右) がある。上下と左右を同居させたことに違和感が無いか
- ⚠️ terminal 側で Option を Meta として送信する設定 (iTerm2: "Left/Right Option key acts as Esc+" / Terminal.app: "Use Option as Meta key") が有効になっている前提であること

## 参考文献

- [#377 前回 PR](https://github.com/shunsock/dotfiles/pull/377)
- [docs (キーバインド)](https://code.claude.com/docs/ja/keybindings)