### PR TITLE
feat(claude): show__implementation_path スキルを追加する

### DIFF
--- a/configs/claude/skills/show__implementation_path/SKILL.md
+++ b/configs/claude/skills/show__implementation_path/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: show__implementation_path
+description: >-
+  worktree やバックグラウンドジョブで実装を終えた後、ユーザーが「反映したい」
+  「実装したファイルの絶対パスを教えて」「どこを変更した？」と依頼したときに起動する。
+  worktree ルート・変更ファイルの絶対パス・元リポジトリ側の反映先パスを定型の一覧で
+  報告する。読み取り専用でありファイルは変更しない。
+tools: Bash
+model: inherit
+---
+
+あなたは git worktree 上の実装成果物の所在を報告する専門家である。
+
+## コンテキスト
+
+Claude Code はバックグラウンドジョブなどで `.claude/worktrees/<name>` の worktree に隔離して実装することがある。
+ユーザーは変更を手元のエディタで開いたり、元リポジトリへ反映したりする。どちらの操作にも変更ファイルの絶対パスが必要である。
+問い合わせのたびに場当たり的に調べると報告の形式が揺れるため、このスキルが報告形式を固定する。
+
+## 実行ステップ
+
+### Phase 1: 作業場所を特定する
+
+worktree ルートと元リポジトリのパスを取得する。
+
+```bash
+git rev-parse --show-toplevel      # 現在の作業ツリーのルート (絶対パス)
+git rev-parse --git-common-dir     # 元リポジトリの .git (絶対パス)
+```
+
+`--git-common-dir` が `<show-toplevel>/.git` と一致する場合は、worktree ではなく元リポジトリで作業している。
+その場合はその旨を報告し、Phase 3 の表から「反映先」列を省略する。
+一致しない場合、元リポジトリのルートは `--git-common-dir` の結果から末尾の `/.git` を除いたパスである。
+
+### Phase 2: 変更ファイルを列挙する
+
+デフォルトブランチとの分岐点を基準に、コミット済みと未コミットの変更を両方収集する。
+
+```bash
+git symbolic-ref --short refs/remotes/origin/HEAD   # 取得できなければ origin/main とみなす
+base=$(git merge-base origin/main HEAD)
+git diff --name-status "$base"..HEAD                # コミット済みの変更
+git status --porcelain                              # 未コミットの変更
+```
+
+### Phase 3: 報告を提示する
+
+出力は次の形式に整形する。パスはすべて絶対パスで書く。
+
+```
+## 実装パス報告
+
+- worktree ルート: /path/to/repo/.claude/worktrees/<name>
+- 元リポジトリ: /path/to/repo
+- ブランチ: <branch>
+
+| 状態 | 実装ファイル (worktree 内) | 反映先 (元リポジトリ側) |
+|---|---|---|
+| added | /path/to/repo/.claude/worktrees/<name>/configs/foo.md | /path/to/repo/configs/foo.md |
+| modified | ... | ... |
+```
+
+未コミットの変更が残っている場合は、表の後にその一覧と未コミットである旨を注記する。
+リモートに PR がある場合は、正規の反映手段は PR のマージであると一言添える。
+
+## 安全上の注意
+
+- このスキルは読み取り専用である。ファイルのコピー・checkout・merge を行ってはならない。
+- 反映 (コピー・マージ・`task apply` など) の実行はユーザーが判断する。必要ならコマンド例の提示までに留める。


### PR DESCRIPTION
## 概要

worktree で実装した変更の絶対パスと元リポジトリ側の反映先パスを、定型フォーマットで報告するスキル `show__implementation_path` を追加する。

## 背景

バックグラウンドジョブは `.claude/worktrees/<name>` の worktree に隔離して実装する。実装完了後、ユーザーが「反映したいので実装した絶対パスを教えて」と問い合わせる会話が繰り返し発生していた。

## 課題

パスの問い合わせのたびに ad hoc に調べて報告しており、報告の形式 (worktree 内パスだけか、反映先も添えるか、未コミット分に触れるか) が会話ごとに揺れていた。ユーザーが反映作業に使える定型の報告が得られない。

## 目標

### 必須項目

- worktree ルート・元リポジトリ・ブランチを冒頭で提示する
- 変更ファイルごとに worktree 内絶対パスと元リポジトリ側の反映先パスを対応表で示す
- コミット済みと未コミットの変更を両方拾う

### 範囲外

- 反映そのものの実行 (コピー・マージ・`task apply`)。スキルは読み取り専用とする

## 採用手法

git のプリミティブ (`rev-parse` / `merge-base` / `diff --name-status` / `status --porcelain`) だけで worktree・元リポジトリ・変更一覧を導出し、報告フォーマットをスキル側で固定する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: 読み取り専用の報告スキル (採用) | 安全。既存の rescue__untracked_worktree と同じ方針で一貫する | 反映はユーザーの手作業になる |
| B: 反映 (コピー) まで実行するスキル | ワンストップで完結する | 元リポジトリの作業コピーを勝手に書き換えるリスクがある |

### 採用理由

元リポジトリはユーザーが同時に触っている可能性があり、スキルが無断で書き込むのは危険である。報告だけを定型化し、反映の判断と実行はユーザーに残す。

## 変更箇所

- `configs/claude/skills/show__implementation_path/SKILL.md`: 実装パス報告スキルの新規追加

## 妥協と制限

- **反映先列の省略**: worktree でない場所で起動された場合、反映先列は意味を持たないため省略する仕様とした

## 検証方法

- textlint (preset-ja-technical-writing / preset-ja-spacing) を実行し 0 件で通過
- 文中ハードラップ検出 (grep 候補抽出 + 目視確認) で該当なしを確認
- 命名が `.claude/rules/claude_skills.md` の `<動詞>__<目的語>` 形式に従うことを確認

## 確認事項

- ⚠️ スキルを読み取り専用に限定した判断 (反映の自動実行を範囲外にした) が意図に合っているか
- 反映には `nix-darwin/` または `nix-os/` での `task apply` が必要 (sudo のためユーザー実行)

## 参考文献

- [.claude/rules/claude_skills.md](https://github.com/shunsock/dotfiles/blob/main/.claude/rules/claude_skills.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)