### PR TITLE
bump: update nix-darwin flake dependencies

### DIFF
--- a/nix-darwin/flake.lock
+++ b/nix-darwin/flake.lock
@@ -1,30 +1,5 @@
 {
   "nodes": {
-    "blueprint": {
-      "inputs": {
-        "nixpkgs": [
-          "llm-agents",
-          "nixpkgs"
-        ],
-        "systems": [
-          "llm-agents",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776249299,
-        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
-        "owner": "numtide",
-        "repo": "blueprint",
-        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "blueprint",
-        "type": "github"
-      }
-    },
     "bun2nix": {
       "inputs": {
         "flake-parts": [
@@ -45,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782772816,
-        "narHash": "sha256-s9BuFv0mRuZx9C1MF8qPHRdcAK14ONi0A5m6E2wqOoM=",
+        "lastModified": 1784665499,
+        "narHash": "sha256-9BMxlTxCCDAeoNLtb1a/st7udtTIJep+wpUzquA29VU=",
         "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "5a39d717029e94163ac223aee8d5c9946cafed1c",
+        "rev": "0f2a1f0b6f42cebe3b149bf62d38754c5e0e9729",
         "type": "github"
       },
       "original": {
@@ -81,11 +56,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -138,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783530528,
-        "narHash": "sha256-GEEeFcevL2odIb/fxI7NYbeleoB5syO5eUmeckDAHfY=",
+        "lastModified": 1783766535,
+        "narHash": "sha256-u0cPzN8mD9R/DcQnO5BGq0xG4W3ZwOnD0RR1IRnYfyw=",
         "owner": "shunsock",
         "repo": "hisui",
-        "rev": "45b56485968a14bfcb6e0070b7b5b0d4717f7ae0",
+        "rev": "c5e51966e045d40f8dc4e780e5df17b04f9bc729",
         "type": "github"
       },
       "original": {
@@ -158,11 +133,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783740085,
-        "narHash": "sha256-qajyHfZY29G2oEQk+uHxmsJcRoBUBXP9maTpFlwP/dI=",
+        "lastModified": 1785119570,
+        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3cd22efe6471dc7365c822bd9ad73a21e55f38fb",
+        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
         "type": "github"
       },
       "original": {
@@ -181,11 +156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783748509,
-        "narHash": "sha256-LbhKux/T2IgfY8gemtl177v92QpK4Q7XEsCS8ImCMnI=",
+        "lastModified": 1785557451,
+        "narHash": "sha256-I8siUPw+9mpsYcWkNQNfizmxzrjrDN0uOTzPVLsSHf0=",
         "owner": "shunsock",
         "repo": "lazynix",
-        "rev": "186caa5d24fb1067b43673bad32eaaaf8bd11960",
+        "rev": "a3f0bb5a690cb0010c8a64d27827e0fbda34c041",
         "type": "github"
       },
       "original": {
@@ -196,7 +171,6 @@
     },
     "llm-agents": {
       "inputs": {
-        "blueprint": "blueprint",
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
@@ -204,11 +178,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1783738657,
-        "narHash": "sha256-gVS7RTK4lDeHc18V5vhbD6yR+dkj6spiUzlgYS2OP9M=",
+        "lastModified": 1786163746,
+        "narHash": "sha256-YBSqmXTxa9+c5tXsNK1h2ZwNBEK5qpg7gICOv/1zBcQ=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "c69b3057113428150630c05682fa3cfbd312b4d5",
+        "rev": "8dac44b62df0f73f156765dc8fa9e3a306370c3e",
         "type": "github"
       },
       "original": {
@@ -240,11 +214,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783475452,
-        "narHash": "sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco=",
+        "lastModified": 1785747939,
+        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "05988b07fb05cbcb50be6bce197b4b5f75b5e61b",
+        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
         "type": "github"
       },
       "original": {
@@ -256,11 +230,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
         "type": "github"
       },
       "original": {
@@ -272,11 +246,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783549019,
-        "narHash": "sha256-0XnckG4ZhBmAsYa9mLuEIFowBG0fDGPLHduQGsbMS4A=",
+        "lastModified": 1785989512,
+        "narHash": "sha256-HFQhkQcl5D1hUNoen3SGHCSFCt2Bg6uP+HgbrnA3InQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74cc63f702f7d60a557e152a57b40fb1fd0f72ac",
+        "rev": "445d861c6d31b4af0c79d8d4be2331f762a361d7",
         "type": "github"
       },
       "original": {
@@ -350,11 +324,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1785945821,
+        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要

nix-darwin の flake 依存 (`nix-darwin/flake.lock`) を定期更新する。

## 背景

nix-darwin 配下の flake 依存は前回更新 (2026-07-11 の bump/nix-20260711) から約 1 ヶ月経過しており、nixpkgs や home-manager を含む各 input に上流の更新が溜まっていた。

## 課題

flake.lock が固定する各 input のリビジョンが古くなり、パッケージやモジュールの更新・修正が取り込めていなかった。

## 目標

### 必須項目

- `task update` (`nix flake update`) で全 input を最新リビジョンへ更新する

### 範囲外

- `task apply` によるシステムへの適用 (sudo が必要なためマージ後にユーザーが手動実行する)
- nix-os / nvimc の依存更新

## 採用手法

運用どおり `nix-darwin/` で `task update` を実行し、生成された flake.lock の差分のみをコミットした。手動での個別 pin は行っていない。

## 変更箇所

- `nix-darwin/flake.lock`: 以下の input を更新
  - `nixpkgs` 2026-07-08 → 2026-08-06
  - `nixpkgs-unstable` 2026-07-08 → 2026-08-05
  - `home-manager` 2026-07-11 → 2026-07-27
  - `hisui` 2026-07-08 → 2026-07-11
  - `lazynix` 2026-07-11 → 2026-08-01
  - `llm-agents` 2026-07-11 → 2026-08-08 (上流の再構成により従属 input の `blueprint` 系が削除され、`bun2nix` / `flake-parts` / `treefmt-nix` などが更新)

## 妥協と制限

- **ビルド未検証のままマージする**: `task apply` は sudo を伴い CI・Claude では実行できないため、実際の適用確認はマージ後のユーザー操作に委ねる。

## 検証方法

- `task update` が正常終了し、flake.lock の差分が上記 input の更新のみであることを確認した

## 確認事項

- ⚠️ マージ後に `nix-darwin/` で `task apply` を手動実行して適用してください。`llm-agents` の入力構成が上流で変わっているため、apply が失敗する場合はこの PR の revert で戻せます。

## 参考文献

- [shunsock/dotfiles bump/nix-20260711 (前回の更新 PR ブランチ)](https://github.com/shunsock/dotfiles/branches)
