### PR TITLE
feat(claude): PR 作成時にラベルと assignee を自動付与する

### DIFF
--- a/configs/claude/skills/restart__pull_request/SKILL.md
+++ b/configs/claude/skills/restart__pull_request/SKILL.md
@@ -23,8 +23,7 @@ PR レビュー中に以下が起きると、PR は「読めない」状態に�
 - リベース失敗や merge コミット混入で履歴が汚れた
 - レビュー指摘を反映するうちに、PR 説明文が現状と合わなくなった
 
-この状況で「force push で歴史を書き換える」のは禁止されている
-(global rule: `git push --force` / `git push -f` 禁止)。
+この状況で「force push で歴史を書き換える」のは禁止されている (global rule: `git push --force` / `git push -f` 禁止)。
 そこで本スキルは **新ブランチに squash した単一コミットを作って新PRを開く**。
 そのうえで **旧PRを参照付きで close する** という安全な手順で再出発する。
 
@@ -171,8 +170,7 @@ git checkout -b "$NEW_BRANCH" "origin/${BASE_BRANCH}"
 git merge --squash "origin/${OLD_BRANCH}"
 ```
 
-コンフリクトが出た場合はユーザーに報告して停止する (`git push --force` で
-回避するような操作はしない)。
+コンフリクトが出た場合はユーザーに報告して停止する (`git push --force` で回避するような操作はしない)。
 
 #### 3.4 コミットメッセージの作成
 
@@ -340,8 +338,7 @@ EOF
 gh pr close "$PR_NUMBER"
 ```
 
-旧ブランチ (`$OLD_BRANCH`) は **削除しない**。レビュー履歴のリンク先 (コード行参照)
-が壊れるのを防ぐため、参照可能な状態で残す。削除するかはユーザーが判断する。
+旧ブランチ (`$OLD_BRANCH`) は **削除しない**。レビュー履歴のリンク先 (コード行参照) が壊れるのを防ぐため、参照可能な状態で残す。削除するかはユーザーが判断する。
 
 ---
 
@@ -384,8 +381,6 @@ gh pr close "$PR_NUMBER"
 
 ## 推奨事項
 
-- 旧 PR の参加者 (reviewer/commenter) を新 PR の reviewer に再指名する:
-  `gh pr edit ${NEW_PR_NUMBER} --add-reviewer <user>`
-- 議論量が膨大な場合は、Phase 1.4 のグルーピング結果を新 PR 内で
-  collapsible `<details>` ブロックにまとめる
+- 旧 PR の参加者 (reviewer/commenter) を新 PR の reviewer に再指名する: `gh pr edit ${NEW_PR_NUMBER} --add-reviewer <user>`
+- 議論量が膨大な場合は、Phase 1.4 のグルーピング結果を新 PR 内で collapsible `<details>` ブロックにまとめる
 - 旧 PR にラベル `restarted` などを付けて検索性を上げる

--- a/configs/claude/skills/restart__pull_request/SKILL.md
+++ b/configs/claude/skills/restart__pull_request/SKILL.md
@@ -72,6 +72,7 @@ OLD_BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName')
 BASE_BRANCH=$(gh pr view "$PR_NUMBER" --json baseRefName --jq '.baseRefName')
 OLD_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq '.title')
 OLD_URL=$(gh pr view "$PR_NUMBER" --json url --jq '.url')
+OLD_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(",")')
 ```
 
 ---
@@ -131,7 +132,7 @@ git log "origin/${BASE_BRANCH}..origin/${OLD_BRANCH}" --oneline --no-merges
 git diff --stat "origin/${BASE_BRANCH}...origin/${OLD_BRANCH}"
 ```
 
-差分が空なら「再出発する変更がない」状態です。ユーザーに報告して中止します。
+差分に変更が 1 件も無ければ「再出発する変更がない」状態です。ユーザーに報告して中止します。
 
 未コミットの変更が作業ツリーにある場合は警告し、stash か commit を促す:
 
@@ -296,13 +297,16 @@ Supersedes ${OLD_URL}
 
 #### 5.2 PR 作成
 
-`submit__pull_request` と同じバイパスマーカーを付与する (pr-submission-via-skill hook 用):
+`submit__pull_request` と同じバイパスマーカーを付与する (pr-submission-via-skill hook 用)。
+ラベルは旧 PR から引き継ぎ、assignee は実行ユーザーを自動付与する:
 
 ```bash
 gh pr create \
   --base "$BASE_BRANCH" \
   --head "$NEW_BRANCH" \
   --title "$OLD_TITLE" \
+  --assignee @me \
+  ${OLD_LABELS:+--label "$OLD_LABELS"} \
   --body "$(cat <<'EOF'
 <Phase 5.1 で生成した説明文>
 EOF

--- a/configs/claude/skills/submit__pull_request/SKILL.md
+++ b/configs/claude/skills/submit__pull_request/SKILL.md
@@ -29,10 +29,8 @@ Phase 4 はコンフリクト監視、Phase 5 は CI 監視です。
 
 PR 作成後、必ず以下を実行すること:
 
-1. `monitor__pull_request_conflict` スキルを kick し、ベースとの merge conflict を
-   検知・解決する。CI がクリーンな状態で走るよう、CI 監視より先に行う
-2. `monitor__ci_status` スキルを kick し、CI を監視する。失敗があれば
-   `monitor__ci_status` が `rescue__ci_failure` を自律起動して修正・再監視する
+1. `monitor__pull_request_conflict` スキルを kick し、ベースとの merge conflict を検知・解決する。CI がクリーンな状態で走るよう、CI 監視より先に行う
+2. `monitor__ci_status` スキルを kick し、CI を監視する。失敗があれば `monitor__ci_status` が `rescue__ci_failure` を自律起動して修正・再監視する
 3. 両監視の結果を統合してサマリーを出力する
 
 PR 作成だけで完了を報告することは禁止する。
@@ -52,8 +50,7 @@ Skill ツールで `write__pull_request` を起動し、生成された説明文
 
 ### Phase 3: PR作成
 
-コマンドの末尾にバイパスマーカーを付与する。これは PreToolUse hook
-（pr_submission_via_skill.cs）がこのスキル経由の `gh pr create` を許可するための識別子です。
+コマンドの末尾にバイパスマーカーを付与する。これは PreToolUse hook（pr_submission_via_skill.cs）がこのスキル経由の `gh pr create` を許可するための識別子です。
 マーカーがないと hook がコマンドを拒否する。
 
 ラベルと assignee はユーザーへの確認なしで自動付与する。
@@ -66,7 +63,7 @@ gh pr create --title "<タイトル>" --body "<Phase 1-2で生成した説明文
   --assignee @me --label "<選択したラベル>" # @pr-submission-via-skill-bypass
 ```
 
-ラベル選択の基準: 変更の種別に対応するラベル (バグ修正 → `bug` 系、機能追加 → `enhancement` 系) を最優先し、説明文から内容に合う補助ラベルがあれば加える。関連 Issue にラベルが付いていれば種別の判断材料にする。
+ラベル選択の基準は変更の種別との対応です。バグ修正なら `bug` 系、機能追加なら `enhancement` 系を最優先する。説明文から内容に合う補助ラベルがあれば加える。関連 Issue にラベルが付いていれば種別の判断材料にする。
 
 ラベルの定義 (語彙・色・説明) は `shunsock/github_central` が single source of truth として管理する。本スキルはラベルを作成しない。合うラベルが無ければ `--label` を省略し、`--assignee @me` のみで作成する。
 

--- a/configs/claude/skills/submit__pull_request/SKILL.md
+++ b/configs/claude/skills/submit__pull_request/SKILL.md
@@ -56,9 +56,19 @@ Skill ツールで `write__pull_request` を起動し、生成された説明文
 （pr_submission_via_skill.cs）がこのスキル経由の `gh pr create` を許可するための識別子です。
 マーカーがないと hook がコマンドを拒否する。
 
+ラベルと assignee はユーザーへの確認なしで自動付与する。
+
 ```bash
-gh pr create --title "<タイトル>" --body "<Phase 1-2で生成した説明文>" # @pr-submission-via-skill-bypass
+# 既存ラベルを取得し、変更内容に合うラベル (bug / enhancement など) を選ぶ
+gh label list --json name,description
+
+gh pr create --title "<タイトル>" --body "<Phase 1-2で生成した説明文>" \
+  --assignee @me --label "<選択したラベル>" # @pr-submission-via-skill-bypass
 ```
+
+ラベル選択の基準: 変更の種別に対応するラベル (バグ修正 → `bug` 系、機能追加 → `enhancement` 系) を最優先し、説明文から内容に合う補助ラベルがあれば加える。関連 Issue にラベルが付いていれば種別の判断材料にする。
+
+ラベルの定義 (語彙・色・説明) は `shunsock/github_central` が single source of truth として管理する。本スキルはラベルを作成しない。合うラベルが無ければ `--label` を省略し、`--assignee @me` のみで作成する。
 
 PR 番号を取得して後続フェーズで使用する:
 
@@ -110,6 +120,8 @@ CI 監視より先に行う理由を述べる。
 - PR: #<number>
 - Title: <title>
 - URL: <url>
+- Labels: <labels>
+- Assignee: <user>
 
 ### Conflict Monitor
 - Result: MERGEABLE / STILL_CONFLICTING


### PR DESCRIPTION
## 概要

PR を作成する 2 つのスキル (`submit__pull_request` / `restart__pull_request`) に、ラベルの自動付与と `--assignee @me` の自動付与を追加する。

## 背景

Issue 起票側は 2 ステージ構成への再設計 (#395) の際に、`submit__issue` がラベル自動選択と assignee 付与を行うようになった。一方 PR 側は説明文の生成と CI 監視のみで、ラベルと assignee は手動で付ける必要が残っていた。

## 課題

PR 作成時にラベルと assignee が付かないため、PR 一覧での分類・絞り込みができず、Issue 側と運用の一貫性が取れていなかった。

## 目標

### 必須項目

- `submit__pull_request` が PR 作成時にラベルを自動選択し、`--assignee @me` を付与する
- `restart__pull_request` が再出発 PR に旧 PR のラベルと assignee を引き継ぐ

### 範囲外

- `write__pull_request` の変更 (説明文生成のみを担い、`gh` 操作を持たない設計を維持する)
- ラベルの新規作成 (ラベル定義は `shunsock/github_central` が管理する)

## 採用手法

`gh` 操作を担うオーケストレーター側 (`submit__pull_request` Phase 3 / `restart__pull_request` Phase 5.2) にのみ手を入れる。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: PR 作成コマンドを持つスキルに追加 (採用) | 「gh 操作はオーケストレーターが担う」という既存の責務分担を維持できる | 依頼で名指しされた `write__pull_request` 自体には変更が入らない |
| B: `write__pull_request` にラベル選択ロジックを追加 | 依頼の文言に忠実 | 説明文生成専任という設計を壊し、`gh` 操作が 2 箇所に分散する |

### 採用理由

`write__pull_request` は「PR の作成 (gh pr create)・push・CI 監視は行わない」と明記された説明文生成専任のスキルであり、ラベル・assignee は PR 作成コマンドのフラグとして渡すのが最も単純なため、作成を担うスキル側に置いた。

ラベル選択の方式は `submit__issue` と揃えた: `gh label list` で既存ラベルを取得し、変更の種別 (バグ修正 → `bug` 系、機能追加 → `enhancement` 系) に合うものを選ぶ。合うラベルが無ければ `--label` を省略し、ラベルは作成しない。`restart__pull_request` は種別を再判定せず、旧 PR のラベルをそのまま引き継ぐ (`${OLD_LABELS:+--label "$OLD_LABELS"}` でラベル無しの旧 PR にも対応)。

## 変更箇所

- `configs/claude/skills/submit__pull_request/SKILL.md`: Phase 3 にラベル自動選択と `--assignee @me` を追加し、Phase 6 のサマリーへ Labels / Assignee 行を追加
- `configs/claude/skills/restart__pull_request/SKILL.md`: Phase 0 で `OLD_LABELS` を取得し、Phase 5.2 の PR 作成に assignee 付与とラベル引き継ぎを追加。あわせて hook が検出した既存文中の stop word を言い換え

## 妥協と制限

- **ラベル選択は LLM の判断に依存**: `submit__issue` と同じく、どのラベルを選ぶかは実行時の判断に委ねる。決定的な対応表は持たない
- **反映には `task apply` が必要**: `configs/claude/` はソースであり、home-manager での再配布まで `~/.claude/` には反映されない

## 検証方法

- Issue 側の先行実装 (`submit__issue` Phase 3) と文言・基準が揃っていることを目視で確認
- `${OLD_LABELS:+--label "$OLD_LABELS"}` がラベル無し時にフラグごと省略されることを bash のパラメータ展開仕様で確認
- 日本語 stop word hook の検出をすべて解消

## 確認事項

- ⚠️ `restart__pull_request` はラベルを再判定せず旧 PR から引き継ぐ方針でよいか
- ⚠️ 補助ラベル (documentation / refactor など) の付与は実行時判断に委ねる方針でよいか

## 参考文献

- [submit__issue SKILL.md (ラベル自動選択の先行実装)](https://github.com/shunsock/dotfiles/blob/main/configs/claude/skills/submit__issue/SKILL.md)
