### PR TITLE
feat(nix-darwin): steipete/tap/gogcli を Homebrew 管理下に追加する

### DIFF
--- a/nix-darwin/flake.nix
+++ b/nix-darwin/flake.nix
@@ -131,12 +131,18 @@
                 # nix-darwin は --force 系を生成しないため、cleanup を明示承認する。
                 extraFlags = [ "--force-cleanup" ];
               };
+              # gogcli は tap-qualified name で参照するため、tap 自体も管理下に置く
+              # (taps に無いと cleanup が untap し、次回の解決に失敗する)。
+              taps = [
+                "steipete/tap"
+              ];
               brews = [
                 "colima"
                 "docker"
                 "docker-buildx"
                 "docker-compose"
                 "curl"
+                "steipete/tap/gogcli"
               ];
               casks = [
                 "aquaskk"


### PR DESCRIPTION
## Background

このマシンで `task apply` が失敗する事象を調査したところ、直接原因は手動インストールされていた `steipete/tap/bird` だった。upstream で `birdclaw` に改名されて formula が消えたため、activation の `brew bundle --force-cleanup` が名前を解決できずエラー終了していた (他の Mac では `bird` が入っていないため再現しなかった)。

`bird` 自体は削除して解決したが、調査の過程で Nix 未管理の formula / cask が複数残っていることが分かった。`cleanup = "zap"` の方針上、これらは次回の apply 成功時に一括削除される。その中で `steipete/tap/gogcli` だけは使い続けたいため、宣言的な管理下へ移す。

## Approach

`homebrew.brews` に tap-qualified name (`steipete/tap/gogcli`) を追加し、あわせて `homebrew.taps` に `steipete/tap` を追加する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: brews + taps に追加 (採用) | cleanup が tap を untap しないため、以降の apply が安定して再現する | tap が 1 つ管理対象に増える |
| B: brews のみに追加 | 差分が最小 | cleanup が Brewfile に無い tap を untap するため、次回の formula 解決が壊れる恐れがある |
| C: Nix 管理にせず手動維持 | 設定変更が不要 | cleanup = "zap" が毎回削除してしまい、そもそも共存できない |

### 採用理由

`brew bundle` の cleanup は Brewfile に宣言されていない tap も削除対象にする。tap-qualified な formula は tap が無いと解決できないため、formula と tap をセットで宣言するのが再現性の観点で唯一安全な形になる。

## What Changed

### gogcli の宣言的管理への移行

- `nix-darwin/flake.nix` - `homebrew.taps` に `steipete/tap` を新設し、`homebrew.brews` に `steipete/tap/gogcli` を追加。tap をセットで管理する理由をコメントで明記した。

## Tradeoffs and Limitations

- **steipete/tap への依存**: 個人 tap のため、今回の `bird` → `birdclaw` 改名のような上流変更で再び activation が壊れるリスクは残る。壊れた場合はこの PR と同様に formula 名を追従させる運用とする。
- **他の未管理パッケージは救済しない**: `sketchybar` / `firefox` / `visual-studio-code` などの未管理 formula / cask は、ユーザー判断により次回 apply の zap 削除に委ねる。

## Testing

sudo を伴う `task apply` は実行できないため、sudo 不要な範囲で検証した:

- `task format` / `task build` / `task check` すべて成功
- 生成された Brewfile (`/nix/store/...-Brewfile`) に `tap "steipete/tap"` と `brew "steipete/tap/gogcli"` が含まれることを確認

実際の activation (`task apply`) はマージ後にローカルで実行して確認する。

## Review Guide

1. `nix-darwin/flake.nix` の homebrew ブロックだけが変更点です。taps を追加した理由のコメントと、brews の追加行を確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
